### PR TITLE
Add analytics package with librato support 

### DIFF
--- a/analytics/base.go
+++ b/analytics/base.go
@@ -15,21 +15,27 @@ type Collector interface {
 var singleton Collector
 
 // Librato configures a librato collector for analytics
-func Librato(waitGroup *sync.WaitGroup, username string, token string, source string, timeout time.Duration) {
+func Librato(username string, token string, source string, timeout time.Duration, waitGroup *sync.WaitGroup) {
 	singleton = NewLibrato(libratoEndpoint, username, token, source, timeout, waitGroup)
 }
 
 // Start starts the analytics collector
 func Start() {
-	singleton.Start()
+	if singleton != nil {
+		singleton.Start()
+	}
 }
 
 // Gauge records a new gauge value
 func Gauge(name string, value float64) {
-	singleton.Gauge(name, value)
+	if singleton != nil {
+		singleton.Gauge(name, value)
+	}
 }
 
 // Stop stops the analytics collector
 func Stop() {
-	singleton.Stop()
+	if singleton != nil {
+		singleton.Stop()
+	}
 }

--- a/analytics/base.go
+++ b/analytics/base.go
@@ -1,0 +1,35 @@
+package analytics
+
+import (
+	"sync"
+	"time"
+)
+
+// Collector is anything which can collect analytics
+type Collector interface {
+	Start()
+	Gauge(name string, value float64)
+	Stop()
+}
+
+var singleton Collector
+
+// Librato configures a librato collector for analytics
+func Librato(waitGroup *sync.WaitGroup, username string, token string, source string, timeout time.Duration) {
+	singleton = NewLibrato(libratoEndpoint, username, token, source, timeout, waitGroup)
+}
+
+// Start starts the analytics collector
+func Start() {
+	singleton.Start()
+}
+
+// Gauge records a new gauge value
+func Gauge(name string, value float64) {
+	singleton.Gauge(name, value)
+}
+
+// Stop stops the analytics collector
+func Stop() {
+	singleton.Stop()
+}

--- a/analytics/base_test.go
+++ b/analytics/base_test.go
@@ -1,0 +1,17 @@
+package analytics_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nyaruka/gocommon/analytics"
+)
+
+func TestAnalytics(t *testing.T) {
+	// all methods are NOOPs if analytics has been configured
+	analytics.Start()
+	analytics.Gauge("foo.bar", 123.45)
+	analytics.Stop()
+
+	analytics.Librato("bob", "1234567", "foo.com", time.Second*30, nil)
+}

--- a/analytics/librato.go
+++ b/analytics/librato.go
@@ -60,10 +60,6 @@ func NewLibrato(url string, username string, token string, source string, timeou
 
 // Start starts our librato sender, callers can use Stop to stop it
 func (c *librato) Start() {
-	if c == nil {
-		return
-	}
-
 	go func() {
 		c.waitGroup.Add(1)
 		defer c.waitGroup.Done()
@@ -89,11 +85,6 @@ func (c *librato) Start() {
 
 // Gauge can be used to add a new gauge to be sent to librato
 func (c *librato) Gauge(name string, value float64) {
-	// if no librato configured, return
-	if c == nil {
-		return
-	}
-
 	// our buffer is full, log an error but continue
 	if len(c.buffer) >= cap(c.buffer) {
 		logrus.Error("unable to add new gauges, buffer full, you may want to increase your buffer size or decrease your timeout")
@@ -105,9 +96,6 @@ func (c *librato) Gauge(name string, value float64) {
 
 // Stop stops our sender, callers can use the WaitGroup used during initialization to block for stop
 func (c *librato) Stop() {
-	if c == nil {
-		return
-	}
 	close(c.stop)
 }
 

--- a/analytics/librato.go
+++ b/analytics/librato.go
@@ -1,0 +1,153 @@
+package analytics
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// The endpoint we post librato to
+var libratoEndpoint = "https://metrics-api.librato.com/v1/metrics"
+
+// basic librato client which can batch events
+type librato struct {
+	url      string
+	username string
+	token    string
+	source   string
+	timeout  time.Duration
+
+	httpClient *http.Client
+	waitGroup  *sync.WaitGroup
+	stop       chan bool
+	buffer     chan gauge
+}
+
+type gauge struct {
+	Name        string  `json:"name"`
+	Value       float64 `json:"value"`
+	MeasureTime int64   `json:"measure_time"`
+}
+
+type payload struct {
+	MeasureTime int64   `json:"measure_time"`
+	Source      string  `json:"source"`
+	Gauges      []gauge `json:"gauges"`
+}
+
+// NewLibrato creates a new librato Sender with the passed in parameters
+func NewLibrato(url string, username string, token string, source string, timeout time.Duration, waitGroup *sync.WaitGroup) Collector {
+	return &librato{
+		url:      url,
+		username: username,
+		token:    token,
+		source:   source,
+		timeout:  timeout,
+
+		httpClient: &http.Client{
+			Timeout: time.Second * 30,
+		},
+		waitGroup: waitGroup,
+		stop:      make(chan bool),
+		buffer:    make(chan gauge, 10000),
+	}
+}
+
+// Start starts our librato sender, callers can use Stop to stop it
+func (c *librato) Start() {
+	if c == nil {
+		return
+	}
+
+	go func() {
+		c.waitGroup.Add(1)
+		defer c.waitGroup.Done()
+
+		logrus.WithField("comp", "librato").Info("started for username ", c.username)
+		for {
+			select {
+			case <-c.stop:
+				for len(c.buffer) > 0 {
+					c.flush(250)
+				}
+				logrus.WithField("comp", "librato").Info("stopped")
+				return
+
+			case <-time.After(c.timeout):
+				for i := 0; i < 4; i++ {
+					c.flush(250)
+				}
+			}
+		}
+	}()
+}
+
+// Gauge can be used to add a new gauge to be sent to librato
+func (c *librato) Gauge(name string, value float64) {
+	// if no librato configured, return
+	if c == nil {
+		return
+	}
+
+	// our buffer is full, log an error but continue
+	if len(c.buffer) >= cap(c.buffer) {
+		logrus.Error("unable to add new gauges, buffer full, you may want to increase your buffer size or decrease your timeout")
+		return
+	}
+
+	c.buffer <- gauge{Name: strings.ToLower(name), Value: value, MeasureTime: time.Now().Unix()}
+}
+
+// Stop stops our sender, callers can use the WaitGroup used during initialization to block for stop
+func (c *librato) Stop() {
+	if c == nil {
+		return
+	}
+	close(c.stop)
+}
+
+func (c *librato) flush(count int) {
+	if len(c.buffer) <= 0 {
+		return
+	}
+
+	// build our payload
+	reqPayload := &payload{
+		MeasureTime: time.Now().Unix(),
+		Source:      c.source,
+		Gauges:      make([]gauge, 0, len(c.buffer)),
+	}
+
+	// read up to our count of gauges
+	for i := 0; i < count; i++ {
+		select {
+		case g := <-c.buffer:
+			reqPayload.Gauges = append(reqPayload.Gauges, g)
+		default:
+			break
+		}
+	}
+
+	// send it off
+	encoded, err := json.Marshal(reqPayload)
+	if err != nil {
+		logrus.WithField("comp", "librato").WithError(err).Error("error encoding librato metrics")
+		return
+	}
+
+	req, _ := http.NewRequest("POST", c.url, bytes.NewReader(encoded))
+	req.SetBasicAuth(c.username, c.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	if _, err := c.httpClient.Do(req); err != nil {
+		logrus.WithField("comp", "librato").WithError(err).Error("error sending librato metrics")
+		return
+	}
+
+	logrus.WithField("comp", "librato").WithField("count", len(reqPayload.Gauges)).Debug("flushed to librato")
+}

--- a/analytics/librato_test.go
+++ b/analytics/librato_test.go
@@ -1,0 +1,62 @@
+package analytics
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLibrato(t *testing.T) {
+	var testRequest *http.Request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := ioutil.ReadAll(r.Body)
+		testRequest = httptest.NewRequest(r.Method, r.URL.String(), bytes.NewBuffer(body))
+		testRequest.Header = r.Header
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	// create a new collector
+	wg := sync.WaitGroup{}
+	collector := NewLibrato(server.URL, "username", "password", "host", 10*time.Millisecond, &wg)
+	collector.Start()
+
+	defer func() {
+		collector.Stop()
+		wg.Wait()
+	}()
+
+	// queue up some events
+	collector.Gauge("event10", 10)
+	collector.Gauge("event11", 11)
+	collector.Gauge("event12", 12)
+
+	// sleep a bit
+	time.Sleep(100 * time.Millisecond)
+
+	// our server should have been called, check the parameters
+	assert.NotNil(t, testRequest)
+	assert.Equal(t, "POST", testRequest.Method)
+
+	body, err := ioutil.ReadAll(testRequest.Body)
+	assert.NoError(t, err)
+
+	var response map[string]interface{}
+	err = json.Unmarshal(body, &response)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "host", response["source"])
+
+	gauges := response["gauges"].([]interface{})
+
+	assert.Equal(t, "event10", gauges[0].(map[string]interface{})["name"])
+	assert.Equal(t, float64(12), gauges[2].(map[string]interface{})["value"])
+}


### PR DESCRIPTION
Few tweaks from what is currently in courier. Felt a little odd having the caller set a global, so..

```go
librato.Default = librato.NewSender(...)
librato.Default.Start()
librato.Default.AddGauge(...)
librato.Default.AddGauge(...)
librato.Default.Stop()
```

becomes...

```go
analytics.Librato(...)
analytics.Start()
analytics.Gauge(...)
analytics.Gauge(...)
analytics.Stop()
```

tho it's still possible to use a different instance like...

```go
librato := analytics.NewLibrato(...)
librato.Start()
librato.Gauge(...)
librato.Gauge(...)
librato.Stop()
```