### PR TITLE
allow single digit shortcodes for tel URNs

### DIFF
--- a/urns/urns.go
+++ b/urns/urns.go
@@ -78,7 +78,7 @@ func IsValidScheme(scheme string) bool {
 }
 
 var nonTelCharsRegex = regexp.MustCompile(`[^0-9a-z]`)
-var telRegex = regexp.MustCompile(`^\+?[a-zA-Z0-9]{2,64}$`)
+var telRegex = regexp.MustCompile(`^\+?[a-zA-Z0-9]{1,64}$`)
 var twitterHandleRegex = regexp.MustCompile(`^[a-zA-Z0-9_]{1,15}$`)
 var emailRegex = regexp.MustCompile(`^[^\s@]+@[^\s@]+$`)
 var viberRegex = regexp.MustCompile(`^[a-zA-Z0-9_=/+]{1,24}$`)

--- a/urns/urns.go
+++ b/urns/urns.go
@@ -78,7 +78,7 @@ func IsValidScheme(scheme string) bool {
 }
 
 var nonTelCharsRegex = regexp.MustCompile(`[^0-9a-z]`)
-var telRegex = regexp.MustCompile(`^\+?[a-zA-Z0-9]{3,64}$`)
+var telRegex = regexp.MustCompile(`^\+?[a-zA-Z0-9]{2,64}$`)
 var twitterHandleRegex = regexp.MustCompile(`^[a-zA-Z0-9_]{1,15}$`)
 var emailRegex = regexp.MustCompile(`^[^\s@]+@[^\s@]+$`)
 var viberRegex = regexp.MustCompile(`^[a-zA-Z0-9_=/+]{1,24}$`)

--- a/urns/urns_test.go
+++ b/urns/urns_test.go
@@ -206,13 +206,13 @@ func TestValidate(t *testing.T) {
 		{"tel:+250788383383", ""},
 		{"tel:+250123", ""},
 		{"tel:1337", ""},
-		{"tel:13", ""}, // two digit shortcodes are a thing
+		{"tel:1", ""}, // one digit shortcodes are a thing
 		{"tel:PRIZES", ""},
 		{"tel:cellbroadcastchannel50", ""},
 
 		// invalid tel numbers
 		{"tel:07883 83383", "invalid tel number"}, // can't have spaces
-		{"tel:1", "invalid tel number"},          // too short
+		{"tel:", "cannot be empty"},          // need a path
 
 		// twitter handles
 		{"twitter:jimmyjo", ""},
@@ -302,7 +302,7 @@ func TestTelURNs(t *testing.T) {
 		{"0788383383", "ZZ", "tel:0788383383", false},
 		{"PRIZES", "RW", "tel:prizes", false},
 		{"PRIZES!", "RW", "tel:prizes", false},
-		{"1", "RW", "", true},
+		{"1", "RW", "tel:1", false},
 		{"123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890", "RW", "", true},
 	}
 

--- a/urns/urns_test.go
+++ b/urns/urns_test.go
@@ -206,12 +206,13 @@ func TestValidate(t *testing.T) {
 		{"tel:+250788383383", ""},
 		{"tel:+250123", ""},
 		{"tel:1337", ""},
+		{"tel:13", ""}, // two digit shortcodes are a thing
 		{"tel:PRIZES", ""},
 		{"tel:cellbroadcastchannel50", ""},
 
 		// invalid tel numbers
 		{"tel:07883 83383", "invalid tel number"}, // can't have spaces
-		{"tel:12", "invalid tel number"},          // too short
+		{"tel:1", "invalid tel number"},          // too short
 
 		// twitter handles
 		{"twitter:jimmyjo", ""},


### PR DESCRIPTION
mailroom logs have a bunch of errors from android channels receiving URNs that are two digits, so ya, those are a thing.

As an aside.. should this package just be part of courier maybe? Go will take care of only pulling in the appropriate parts no?