### PR TITLE
Add urns.Parse function

### DIFF
--- a/urns/urns.go
+++ b/urns/urns.go
@@ -134,6 +134,16 @@ func NewURNFromParts(scheme string, path string, query string, display string) (
 	return urn, nil
 }
 
+// Parse parses a URN from the given string. The returned URN is only guaranteed to be structurally valid.
+func Parse(s string) (URN, error) {
+	parsed, err := parseURN(s)
+	if err != nil {
+		return NilURN, err
+	}
+
+	return URN(parsed.String()), nil
+}
+
 // ToParts splits the URN into scheme, path and display parts
 func (u URN) ToParts() (string, string, string, string) {
 	parsed, err := parseURN(string(u))

--- a/urns/urns_test.go
+++ b/urns/urns_test.go
@@ -192,6 +192,33 @@ func TestLocalize(t *testing.T) {
 	}
 }
 
+func TestParse(t *testing.T) {
+	testCases := []struct {
+		input         string
+		urn           URN
+		expectedError string
+	}{
+		{"xxxx", NilURN, "path cannot be empty"},
+		{"tel:", NilURN, "path cannot be empty"},
+		{":xxxx", NilURN, "scheme cannot be empty"},
+		{"tel:46362#rrh#gege", NilURN, "fragment component can only come after path or query components"},
+
+		// no semantic validation
+		{"xyz:abc", URN("xyz:abc"), ""},
+		{"tel:****", URN("tel:****"), ""},
+	}
+
+	for _, tc := range testCases {
+		actual, err := Parse(tc.input)
+		if tc.expectedError != "" {
+			assert.EqualError(t, err, tc.expectedError, "error mismatch for %s", tc.input)
+		} else {
+			assert.NoError(t, err, "unexpected error for %s", tc.input)
+			assert.Equal(t, tc.urn, actual, "parsed URN mismatch for %s", tc.input)
+		}
+	}
+}
+
 func TestValidate(t *testing.T) {
 	testCases := []struct {
 		urn           URN


### PR DESCRIPTION
Provides a way to make a URN from a string that might not be strictly valid, but at least has the right structure