### PR TITLE
Discord ID URN type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.12.x, 1.13.x]
+        go-version: [1.13.x, 1.14.x]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v1.2.0
+----------
+ * Add VK scheme
+ * Replace Travis with github actions
+
 v1.1.1
 ----------
  * Add urns.Parse function


### PR DESCRIPTION
This adds a URN type for Discord IDs. This enables courier to send/receive messages to/from the standalone discord proxy.
See:
https://github.com/rapidpro/rapidpro/issues/1252