### PR TITLE
📵 ParseNumber should ignore numbers which are only possible as local numbers

### DIFF
--- a/urns/utils.go
+++ b/urns/utils.go
@@ -13,10 +13,10 @@ func ParseNumber(s, country string) (string, error) {
 		return "", errors.Wrap(err, "unable to parse number")
 	}
 
-	// if it looks like a possible number, return it formatted as E164
-	if phonenumbers.IsPossibleNumber(parsed) {
-		return phonenumbers.Format(parsed, phonenumbers.E164), nil
+	// check if this is possible number, excluding local-only options
+	if phonenumbers.IsPossibleNumberWithReason(parsed) != phonenumbers.IS_POSSIBLE {
+		return "", errors.New("not a possible number")
 	}
 
-	return "", errors.New("not a possible number")
+	return phonenumbers.Format(parsed, phonenumbers.E164), nil
 }

--- a/urns/utils_test.go
+++ b/urns/utils_test.go
@@ -1,0 +1,35 @@
+package urns_test
+
+import (
+	"testing"
+
+	"github.com/nyaruka/gocommon/urns"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseNumber(t *testing.T) {
+	tcs := []struct {
+		input   string
+		country string
+		parsed  string
+	}{
+		{"+250788123123", "", "+250788123123"},    // international number fine without country
+		{"+250 788 123-123", "", "+250788123123"}, // fine if not E164 formatted
+		{"0788123123", "RW", "+250788123123"},
+		{"206 555 1212", "US", "+12065551212"},
+		{"12065551212", "US", "+12065551212"}, // country code but no +
+		{"5912705", "US", ""},                 // is only possible as a local number so ignored
+		{"10000", "US", ""},
+	}
+
+	for _, tc := range tcs {
+		if tc.parsed != "" {
+			parsed, err := urns.ParseNumber(tc.input, tc.country)
+			assert.NoError(t, err, "unexpected error for '%s'", tc.input)
+			assert.Equal(t, parsed, tc.parsed, "result mismatch for '%s'", tc.input)
+		} else {
+			_, err := urns.ParseNumber(tc.input, tc.country)
+			assert.Error(t, err, "expected error for '%s'", tc.input)
+		}
+	}
+}


### PR DESCRIPTION
Need to be careful leaning on `phonenumbers.IsPossibleNumber` since it includes local only numbers https://github.com/nyaruka/phonenumbers/blob/5cebec5f23b923a5ffab981e9b1922fa650497b1/phonenumbers.go#L2265