### PR TITLE
Add option to save request immediately after creating recorder

### DIFF
--- a/httpx/recorder.go
+++ b/httpx/recorder.go
@@ -53,7 +53,6 @@ func (r *Recorder) SaveRequest() error {
 		return errors.Wrapf(err, "error dumping request")
 	}
 	r.Request.Body = ioutil.NopCloser(bytes.NewBuffer(body))
-	fmt.Println(string(r.requestTrace))
 	return nil
 }
 


### PR DESCRIPTION
Inbound request tracing is a bit annoying in go because `r.Body` is a stream and reading it destroys it. We use Recorder in a few places in mailroom but get into trouble where downstream items read the body of the request without first cloning it. That seems like that really should be a concern of the recorder and not downstream clients of the request, so this adds a `SaveRequest` method on Recorder which immediately saves the request trace for later use as a trace. Made this an option since I know we use Recorder in places where large request bodies can be a problem. (we'll just insert this here on the mailroom side to guarantee we are getting the whole request for ivr items: https://github.com/nyaruka/mailroom/blob/master/web/ivr/ivr.go#L36)