### PR TITLE
gsm7: Fix U+000C, form feed(\f), instead of space, for 0x0A

### DIFF
--- a/gsm7/gsm7.go
+++ b/gsm7/gsm7.go
@@ -136,7 +136,7 @@ var baseGSM7 = map[rune]byte{
 
 // extended gsm7 characters, these my be preceded by our escape
 var extendedGSM7 = map[rune]byte{
-	' ':  0x0A,
+	'\f': 0x0A,
 	'^':  0x14,
 	'{':  0x28,
 	'}':  0x29,

--- a/gsm7/gsm7_test.go
+++ b/gsm7/gsm7_test.go
@@ -1,6 +1,7 @@
 package gsm7_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/nyaruka/gocommon/gsm7"
@@ -73,6 +74,10 @@ func TestSegments(t *testing.T) {
 		Segments int
 	}{
 		{"", 1},
+		{strings.Repeat(" ", 160), 1},
+		{strings.Repeat(" ", 161), 2},
+		{strings.Repeat("\f", 80), 1},
+		{strings.Repeat("\f", 81), 2},
 		{"hello", 1},
 		{"“word”", 1},
 		{hundredChars + fiftyChars + tenChars, 1},


### PR DESCRIPTION
FF should be `\f`, instead of ' ', space, to calculate segment correctly.