### PR TITLE
🛀 Add support for sanitizing a response trace by stripping nulls

### DIFF
--- a/httpx/http.go
+++ b/httpx/http.go
@@ -76,24 +76,24 @@ func (t *Trace) String() string {
 
 // SanitizedResponse returns a valid UTF-8 string version of trace, substituting the body with a placeholder
 // if it isn't valid UTF-8. It also strips any NULL characters as not all external dependencies can handle those.
-func (t *Trace) SanitizedResponse(placeholder string) string {
+func (t *Trace) SanitizedResponse(placeholder string) []byte {
 	b := &bytes.Buffer{}
 
 	// ensure headers section is valid
-	b.Write(stripNullChars(bytes.ToValidUTF8(t.ResponseTrace, nil)))
+	b.Write(replaceNullChars(bytes.ToValidUTF8(t.ResponseTrace, nil)))
 
 	// only include body if it's valid UTF-8 as it could be a binary file or anything
 	if utf8.Valid(t.ResponseBody) {
-		b.Write(stripNullChars(t.ResponseBody))
+		b.Write(replaceNullChars(t.ResponseBody))
 	} else {
 		b.Write([]byte(placeholder))
 	}
 
-	return b.String()
+	return b.Bytes()
 }
 
-func stripNullChars(b []byte) []byte {
-	return bytes.ReplaceAll(b, []byte{0}, nil)
+func replaceNullChars(b []byte) []byte {
+	return bytes.ReplaceAll(b, []byte{0}, []byte(`�`))
 }
 
 // DoTrace makes the given request saving traces of the complete request and response

--- a/httpx/http.go
+++ b/httpx/http.go
@@ -80,7 +80,7 @@ func (t *Trace) SanitizedResponse(placeholder string) []byte {
 	b := &bytes.Buffer{}
 
 	// ensure headers section is valid
-	b.Write(replaceNullChars(bytes.ToValidUTF8(t.ResponseTrace, nil)))
+	b.Write(replaceNullChars(bytes.ToValidUTF8(t.ResponseTrace, []byte(`�`))))
 
 	// only include body if it's valid UTF-8 as it could be a binary file or anything
 	if utf8.Valid(t.ResponseBody) {

--- a/httpx/http_test.go
+++ b/httpx/http_test.go
@@ -28,6 +28,9 @@ func newTestHTTPServer(port int) *httptest.Server {
 		case "success":
 			contentType = "text/plain; charset=utf-8"
 			data = []byte(`{ "ok": "true" }`)
+		case "nullchars":
+			contentType = "text/plain; charset=utf-8"
+			data = []byte("ab\x00cd\x00")
 		case "binary":
 			contentType = "application/octet-stream"
 			data = make([]byte, 1000)
@@ -76,7 +79,7 @@ func TestDoTrace(t *testing.T) {
 	assert.Equal(t, time.Date(2019, 10, 7, 15, 21, 30, 123456789, time.UTC), trace.StartTime)
 	assert.Equal(t, time.Date(2019, 10, 7, 15, 21, 31, 123456789, time.UTC), trace.EndTime)
 
-	assert.Equal(t, "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n{ \"ok\": \"true\" }", string(trace.ResponseTraceUTF8("...")))
+	assert.Equal(t, "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n{ \"ok\": \"true\" }", string(trace.SanitizedResponse("...")))
 	assert.Equal(t, ">>>>>>>> GET http://127.0.0.1:52025?cmd=success\nGET /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:52025\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip\r\n\r\n\n<<<<<<<<\nHTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n{ \"ok\": \"true\" }", trace.String())
 
 	// test with a binary response
@@ -88,7 +91,18 @@ func TestDoTrace(t *testing.T) {
 	assert.Equal(t, "GET /?cmd=binary HTTP/1.1\r\nHost: 127.0.0.1:52025\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip\r\n\r\n", string(trace.RequestTrace))
 	assert.Equal(t, "HTTP/1.1 200 OK\r\nContent-Length: 1000\r\nContent-Type: application/octet-stream\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n", string(trace.ResponseTrace))
 	assert.Equal(t, 1000, len(trace.ResponseBody))
-	assert.Equal(t, "HTTP/1.1 200 OK\r\nContent-Length: 1000\r\nContent-Type: application/octet-stream\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n...", string(trace.ResponseTraceUTF8("...")))
+	assert.Equal(t, "HTTP/1.1 200 OK\r\nContent-Length: 1000\r\nContent-Type: application/octet-stream\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n...", string(trace.SanitizedResponse("...")))
+
+	// test with a response containing null chars
+	request, err = httpx.NewRequest("GET", server.URL+"?cmd=nullchars", nil, nil)
+	require.NoError(t, err)
+
+	trace, err = httpx.DoTrace(http.DefaultClient, request, nil, nil, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, "GET /?cmd=nullchars HTTP/1.1\r\nHost: 127.0.0.1:52025\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip\r\n\r\n", string(trace.RequestTrace))
+	assert.Equal(t, "HTTP/1.1 200 OK\r\nContent-Length: 6\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n", string(trace.ResponseTrace))
+	assert.Equal(t, 6, len(trace.ResponseBody))
+	assert.Equal(t, "HTTP/1.1 200 OK\r\nContent-Length: 6\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\nabcd", string(trace.SanitizedResponse("...")))
 }
 
 func TestMaxBodyBytes(t *testing.T) {

--- a/httpx/http_test.go
+++ b/httpx/http_test.go
@@ -30,7 +30,7 @@ func newTestHTTPServer(port int) *httptest.Server {
 			data = []byte(`{ "ok": "true" }`)
 		case "nullchars":
 			contentType = "text/plain; charset=utf-8"
-			data = []byte("ab\x00cd\x00")
+			data = []byte("ab\x00cd\x00\x00")
 		case "binary":
 			contentType = "application/octet-stream"
 			data = make([]byte, 1000)
@@ -100,9 +100,9 @@ func TestDoTrace(t *testing.T) {
 	trace, err = httpx.DoTrace(http.DefaultClient, request, nil, nil, -1)
 	assert.NoError(t, err)
 	assert.Equal(t, "GET /?cmd=nullchars HTTP/1.1\r\nHost: 127.0.0.1:52025\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip\r\n\r\n", string(trace.RequestTrace))
-	assert.Equal(t, "HTTP/1.1 200 OK\r\nContent-Length: 6\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n", string(trace.ResponseTrace))
-	assert.Equal(t, 6, len(trace.ResponseBody))
-	assert.Equal(t, "HTTP/1.1 200 OK\r\nContent-Length: 6\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\nabcd", string(trace.SanitizedResponse("...")))
+	assert.Equal(t, "HTTP/1.1 200 OK\r\nContent-Length: 7\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n", string(trace.ResponseTrace))
+	assert.Equal(t, 7, len(trace.ResponseBody))
+	assert.Equal(t, "HTTP/1.1 200 OK\r\nContent-Length: 7\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\nab�cd��", string(trace.SanitizedResponse("...")))
 }
 
 func TestMaxBodyBytes(t *testing.T) {


### PR DESCRIPTION
In addition to ignoring invalid UTF8. Turns out Postgres really doesn't like null chars: https://www.commandprompt.com/blog/null-characters-workarounds-arent-good-enough/