### PR TITLE
Add `syncx.HashedMutexMap`

### DIFF
--- a/syncx/sync.go
+++ b/syncx/sync.go
@@ -1,0 +1,63 @@
+package syncx
+
+import (
+	"crypto/md5"
+	"encoding/binary"
+	"sync"
+)
+
+// MutexMap is a thread-safe map that provides a mutex for each key.
+//
+// m := MutexMap{}
+// unlock := m.Lock("key1")
+// defer unlock()
+//
+// Note that mutexes are not removed from the map when they are unlocked.
+//
+type MutexMap struct {
+	mutexes sync.Map
+}
+
+// Lock locks on the given key and returns a function to unlock.
+func (m *MutexMap) Lock(key string) func() {
+	return m.lock(key)
+}
+
+func (m *MutexMap) lock(k any) func() {
+	value, _ := m.mutexes.LoadOrStore(k, &sync.Mutex{})
+	mtx := value.(*sync.Mutex)
+	mtx.Lock()
+
+	return func() { mtx.Unlock() }
+}
+
+// Range is the same as sync.Map.Range.
+func (m *MutexMap) Range(f func(key, value any) bool) {
+	m.mutexes.Range(f)
+}
+
+// HashedMutexMap is a MutexMap which reduces keys to a fixed number of bits so that there will only ever be a fixed
+// number of mutexes. This means that there's no guarantee that two disctinct keys will use separate locks, but it is
+// guaranteed that different calls with the same key, will use the same lock.
+type HashedMutexMap struct {
+	MutexMap
+	keybits int
+}
+
+// NewHashedMutexMap
+func NewHashedMutexMap(keybits int) *HashedMutexMap {
+	return &HashedMutexMap{keybits: keybits}
+}
+
+func (m *HashedMutexMap) Lock(key string) func() {
+	return m.lock(hashToBits(key, m.keybits))
+}
+
+// hashes and reduces the given string to an integer with the given number of bits
+func hashToBits(s string, bits int) uint32 {
+	h := md5.New()
+	h.Write([]byte(s))
+	n := binary.BigEndian.Uint32(h.Sum(nil)[0:4])
+	shift := uint32(32 - bits)
+	return (n << shift) >> shift
+}

--- a/syncx/sync_test.go
+++ b/syncx/sync_test.go
@@ -1,0 +1,89 @@
+package syncx_test
+
+import (
+	"math/rand"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nyaruka/gocommon/syncx"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMutexMap(t *testing.T) {
+	wg := sync.WaitGroup{}
+	m := syncx.MutexMap{}
+
+	counters := make(map[string]int)
+	countersMutex := sync.Mutex{}
+
+	job := func(index int, key string, millis int) {
+		unlock := m.Lock(key)
+
+		countersMutex.Lock()
+		counters[key]++
+		assert.Equal(t, 1, counters[key])
+		countersMutex.Unlock()
+
+		time.Sleep(time.Millisecond * time.Duration(millis))
+
+		countersMutex.Lock()
+		counters[key]--
+		countersMutex.Unlock()
+
+		unlock()
+	}
+
+	for i, tc := range []struct {
+		key    string
+		millis int
+	}{
+		{key: "abc", millis: 500},
+		{key: "abc", millis: 500},
+		{key: "def", millis: 200},
+		{key: "ghi", millis: 300},
+		{key: "def", millis: 200},
+	} {
+		wg.Add(1)
+		index := i
+		key := tc.key
+		millis := tc.millis
+
+		go func() {
+			defer wg.Done()
+			job(index, key, millis)
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestHashedMutexMap(t *testing.T) {
+	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+	randString := func(n int) string {
+		b := make([]rune, n)
+		for i := range b {
+			b[i] = letters[rand.Intn(len(letters))]
+		}
+		return string(b)
+	}
+
+	m := syncx.NewHashedMutexMap(4)
+
+	for i := 0; i < 1000; i++ {
+		unlock := m.Lock(randString(10))
+		unlock()
+	}
+
+	// get all the keys from the map
+	keys := make([]any, 0, 16)
+	m.Range(func(key, value any) bool {
+		keys = append(keys, key)
+		return true
+	})
+	sort.Slice(keys, func(i, j int) bool { return keys[i].(uint32) < keys[j].(uint32) })
+
+	assert.Equal(t, []any{uint32(0), uint32(1), uint32(2), uint32(3), uint32(4), uint32(5), uint32(6), uint32(7), uint32(8), uint32(9), uint32(10), uint32(11), uint32(12), uint32(13), uint32(14), uint32(15)}, keys)
+}


### PR DESCRIPTION
Would use this for locking around media URL lookups in mailroom or courier. We want simultaneous lookups of a given url to always be synchronized. It doesn't matter if lookups for a different url occasionally share the same locking, but generally we don't want a lookup of url A to block lookups of urls B, C etc.