### PR TITLE
Storage types should have object permissions/acl set via constructor

### DIFF
--- a/storage/base.go
+++ b/storage/base.go
@@ -14,18 +14,19 @@ type Storage interface {
 	Get(ctx context.Context, path string) (string, []byte, error)
 
 	// Put stores the given file at the given path
-	Put(ctx context.Context, path string, contentType string, contents []byte) (string, error)
+	Put(ctx context.Context, path string, contentType string, body []byte) (string, error)
 
 	// BatchPut stores the given uploads, returning the URLs of the files after upload
 	BatchPut(ctx context.Context, uploads []*Upload) error
 }
 
-// Upload is our type for a file to upload
+// Upload is our type for a file in a batch upload
 type Upload struct {
 	Path        string
-	Body        []byte
 	ContentType string
-	ACL         string
-	URL         string
-	Error       error
+	Body        []byte
+
+	// set by BatchPut
+	URL   string
+	Error error
 }

--- a/storage/fs.go
+++ b/storage/fs.go
@@ -15,8 +15,8 @@ type fsStorage struct {
 }
 
 // NewFS creates a new file system storage service suitable for use in tests
-func NewFS(directory string) Storage {
-	return &fsStorage{directory: directory, perms: 0766}
+func NewFS(directory string, perms os.FileMode) Storage {
+	return &fsStorage{directory: directory, perms: perms}
 }
 
 func (s *fsStorage) Name() string {
@@ -37,11 +37,11 @@ func (s *fsStorage) Test(ctx context.Context) error {
 
 func (s *fsStorage) Get(ctx context.Context, path string) (string, []byte, error) {
 	fullPath := filepath.Join(s.directory, path)
-	contents, err := os.ReadFile(fullPath)
-	return "", contents, err
+	body, err := os.ReadFile(fullPath)
+	return "", body, err
 }
 
-func (s *fsStorage) Put(ctx context.Context, path string, contentType string, contents []byte) (string, error) {
+func (s *fsStorage) Put(ctx context.Context, path string, contentType string, body []byte) (string, error) {
 	fullPath := filepath.Join(s.directory, path)
 
 	err := os.MkdirAll(filepath.Dir(fullPath), s.perms)
@@ -49,7 +49,7 @@ func (s *fsStorage) Put(ctx context.Context, path string, contentType string, co
 		return "", err
 	}
 
-	err = os.WriteFile(fullPath, contents, s.perms)
+	err = os.WriteFile(fullPath, body, s.perms)
 	if err != nil {
 		return "", err
 	}

--- a/storage/fs_test.go
+++ b/storage/fs_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/nyaruka/gocommon/storage"
 	"github.com/nyaruka/gocommon/uuids"
 
@@ -18,7 +17,7 @@ func TestFS(t *testing.T) {
 	uuids.SetGenerator(uuids.NewSeededGenerator(12345))
 	defer uuids.SetGenerator(uuids.DefaultGenerator)
 
-	s := storage.NewFS("_testing")
+	s := storage.NewFS("_testing", 0766)
 	assert.NoError(t, s.Test(ctx))
 
 	// break our ability to write to that directory
@@ -45,20 +44,18 @@ func TestFSBatchPut(t *testing.T) {
 	uuids.SetGenerator(uuids.NewSeededGenerator(12345))
 	defer uuids.SetGenerator(uuids.DefaultGenerator)
 
-	s := storage.NewFS("_testing")
+	s := storage.NewFS("_testing", 0766)
 
 	uploads := []*storage.Upload{
 		{
 			Path:        "https://mybucket.s3.amazonaws.com/foo/thing1",
 			Body:        []byte(`HELLOWORLD`),
 			ContentType: "text/plain",
-			ACL:         s3.BucketCannedACLPrivate,
 		},
 		{
 			Path:        "https://mybucket.s3.amazonaws.com/foo/thing2",
 			Body:        []byte(`HELLOWORLD2`),
 			ContentType: "text/plain",
-			ACL:         s3.BucketCannedACLPrivate,
 		},
 	}
 

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -42,7 +42,7 @@ func (c *testS3Client) PutObjectWithContext(ctx context.Context, input *s3.PutOb
 
 func TestS3Test(t *testing.T) {
 	client := &testS3Client{}
-	s3 := storage.NewS3(client, "mybucket", "us-east-1", 1)
+	s3 := storage.NewS3(client, "mybucket", "us-east-1", s3.BucketCannedACLPublicRead, 1)
 
 	assert.NoError(t, s3.Test(context.Background()))
 
@@ -54,7 +54,7 @@ func TestS3Test(t *testing.T) {
 func TestS3Get(t *testing.T) {
 	ctx := context.Background()
 	client := &testS3Client{}
-	s := storage.NewS3(client, "mybucket", "us-east-1", 1)
+	s := storage.NewS3(client, "mybucket", "us-east-1", s3.BucketCannedACLPublicRead, 1)
 
 	client.getObjectReturnValue = &s3.GetObjectOutput{
 		ContentType: aws.String("text/plain"),
@@ -75,7 +75,7 @@ func TestS3Get(t *testing.T) {
 func TestS3Put(t *testing.T) {
 	ctx := context.Background()
 	client := &testS3Client{}
-	s := storage.NewS3(client, "mybucket", "us-east-1", 1)
+	s := storage.NewS3(client, "mybucket", "us-east-1", s3.BucketCannedACLPublicRead, 1)
 
 	url, err := s.Put(ctx, "/foo/things", "text/plain", []byte(`HELLOWORLD`))
 	assert.NoError(t, err)
@@ -91,20 +91,18 @@ func TestS3BatchPut(t *testing.T) {
 
 	ctx := context.Background()
 	client := &testS3Client{}
-	s := storage.NewS3(client, "mybucket", "us-east-1", 10)
+	s := storage.NewS3(client, "mybucket", "us-east-1", s3.BucketCannedACLPrivate, 10)
 
 	uploads := []*storage.Upload{
 		{
 			Path:        "https://mybucket.s3.us-east-1.amazonaws.com/foo/thing1",
 			Body:        []byte(`HELLOWORLD`),
 			ContentType: "text/plain",
-			ACL:         s3.BucketCannedACLPrivate,
 		},
 		{
 			Path:        "https://mybucket.s3.us-east-1.amazonaws.com/foo/thing2",
 			Body:        []byte(`HELLOWORLD2`),
 			ContentType: "text/plain",
-			ACL:         s3.BucketCannedACLPrivate,
 		},
 	}
 
@@ -115,7 +113,7 @@ func TestS3BatchPut(t *testing.T) {
 	assert.NotEmpty(t, uploads[1].URL)
 
 	// try again, with a single thread and throwing an error
-	s = storage.NewS3(client, "mybucket", "us-east-1", 1)
+	s = storage.NewS3(client, "mybucket", "us-east-1", s3.BucketCannedACLPrivate, 1)
 	client.returnError = errors.New("boom")
 
 	uploads[0].URL = ""


### PR DESCRIPTION
So that the `Storage` interface is completely storage type agnostic