### PR TITLE
URN schemes tweaks (from trying to upgrade goflow)

### DIFF
--- a/urns/phone.go
+++ b/urns/phone.go
@@ -34,10 +34,10 @@ func ParsePhone(raw string, country i18n.Country) (URN, error) {
 			return NilURN, errors.New("invalid country code")
 		}
 
-		return NewFromParts(Phone, raw, "", "")
+		return NewFromParts(Phone.Prefix, raw, "", "")
 	}
 
-	return NewFromParts(Phone, number, "", "")
+	return NewFromParts(Phone.Prefix, number, "", "")
 }
 
 // tries to extract a valid phone number or shortcode from the given string

--- a/urns/schemes.go
+++ b/urns/schemes.go
@@ -46,13 +46,14 @@ func init() {
 }
 
 var schemeByPrefix = map[string]*Scheme{}
-var schemes = []*Scheme{}
+var Schemes = []*Scheme{}
 
 func register(s *Scheme) {
 	schemeByPrefix[s.Prefix] = s
-	schemes = append(schemes, s)
+	Schemes = append(Schemes, s)
 }
 
+// Scheme represents a URN scheme, e.g. tel, email, etc.
 type Scheme struct {
 	Prefix    string
 	Name      string

--- a/urns/urns.go
+++ b/urns/urns.go
@@ -17,11 +17,6 @@ func IsValidScheme(scheme string) bool {
 	return valid
 }
 
-// Schemes returns the valid URN schemes
-func Schemes() []*Scheme {
-	return schemes
-}
-
 // URN represents a Universal Resource Name, we use this for contact identifiers like phone numbers etc..
 type URN string
 
@@ -40,8 +35,8 @@ func newFromParts(scheme, path, query, display string) URN {
 }
 
 // NewFromParts returns a validated URN for the given scheme, path, query and display
-func NewFromParts(scheme *Scheme, path, query, display string) (URN, error) {
-	urn := newFromParts(scheme.Prefix, path, query, display)
+func NewFromParts(scheme, path, query, display string) (URN, error) {
+	urn := newFromParts(scheme, path, query, display)
 
 	if err := urn.Validate(); err != nil {
 		return NilURN, err
@@ -51,7 +46,7 @@ func NewFromParts(scheme *Scheme, path, query, display string) (URN, error) {
 
 // New returns a validated URN for the given scheme and path
 func New(scheme *Scheme, path string) (URN, error) {
-	return NewFromParts(scheme, path, "", "")
+	return NewFromParts(scheme.Prefix, path, "", "")
 }
 
 // Parse parses a URN from the given string. The returned URN is only guaranteed to be structurally valid.

--- a/urns/urns_test.go
+++ b/urns/urns_test.go
@@ -12,9 +12,6 @@ import (
 func TestIsValidScheme(t *testing.T) {
 	assert.True(t, urns.IsValidScheme("tel"))
 	assert.False(t, urns.IsValidScheme("xyz"))
-
-	assert.Len(t, urns.Schemes(), 20)
-	assert.Equal(t, "Discord", urns.Schemes()[0].Name)
 }
 
 func TestURNProperties(t *testing.T) {
@@ -70,7 +67,7 @@ func TestNewFromParts(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		urn, err := urns.NewFromParts(tc.scheme, tc.path, "", tc.display)
+		urn, err := urns.NewFromParts(tc.scheme.Prefix, tc.path, "", tc.display)
 		identity := urn.Identity()
 
 		assert.Equal(t, tc.expected, urn, "from parts mismatch for: %s, %s, %s", tc.scheme, tc.path, tc.display)


### PR DESCRIPTION
1. Tweak `urns.NewFromParts` so scheme is a string
2. Export the `urns.Schemes` slice instead of exposing via function