### PR TITLE
For `syncx.Batcher`, `dynamo.Writer` and `dynamo.Spool`, pass `WaitGroup` via start method

### DIFF
--- a/aws/dynamo/spool_test.go
+++ b/aws/dynamo/spool_test.go
@@ -29,12 +29,12 @@ func TestSpool(t *testing.T) {
 	item2, _ := dynamo.Marshal(&ThingItem{ThingKey: ThingKey{PK: "P22", SK: "SBB"}, Name: "Thing 2", Count: 234})
 	item3, _ := dynamo.Marshal(&ThingItem{ThingKey: ThingKey{PK: "P33", SK: "SAA"}, Name: "Thing 3", Count: 345})
 
-	wg := &sync.WaitGroup{}
-	spool := dynamo.NewSpool(client, "./_test_spool", 30*time.Second, wg)
+	spool := dynamo.NewSpool(client, "./_test_spool", 30*time.Second)
 
 	defer spool.Delete()
 
-	err = spool.Start()
+	wg := &sync.WaitGroup{}
+	err = spool.Start(wg)
 	assert.NoError(t, err)
 
 	err = spool.Add("TestSpool", []map[string]types.AttributeValue{item1, item2})
@@ -50,8 +50,8 @@ func TestSpool(t *testing.T) {
 	wg.Wait()
 
 	// Start new spool to verify it can read the existing spool files
-	spool = dynamo.NewSpool(client, "./_test_spool", 100*time.Millisecond, wg)
-	spool.Start()
+	spool = dynamo.NewSpool(client, "./_test_spool", 100*time.Millisecond)
+	spool.Start(wg)
 	assert.Equal(t, 3, spool.Size())
 
 	// Give spool time to try a flush

--- a/aws/dynamo/writer_test.go
+++ b/aws/dynamo/writer_test.go
@@ -20,13 +20,13 @@ func TestWriter(t *testing.T) {
 
 	wg := &sync.WaitGroup{}
 
-	spool := dynamo.NewSpool(client, "./_test_spool", 30*time.Second, wg)
-	spool.Start()
+	spool := dynamo.NewSpool(client, "./_test_spool", 30*time.Second)
+	spool.Start(wg)
 
 	defer spool.Delete()
 
-	writer := dynamo.NewWriter(client, "TestWriter", 100*time.Millisecond, 10, spool, wg)
-	writer.Start()
+	writer := dynamo.NewWriter(client, "TestWriter", 100*time.Millisecond, 10, spool)
+	writer.Start(wg)
 
 	for i := range 10 {
 		rem, err := writer.Write(&ThingItem{ThingKey: ThingKey{PK: "test", SK: "item" + fmt.Sprint(i)}, Name: "Item " + fmt.Sprint(i), Count: i})

--- a/syncx/batcher_test.go
+++ b/syncx/batcher_test.go
@@ -12,12 +12,12 @@ import (
 func TestBatcher(t *testing.T) {
 	batches := make([][]int, 0)
 
-	wg := &sync.WaitGroup{}
 	b := syncx.NewBatcher(func(batch []int) {
 		batches = append(batches, batch)
-	}, 2, time.Second, 3, wg)
+	}, 2, time.Second, 3)
 
-	b.Start()
+	wg := &sync.WaitGroup{}
+	b.Start(wg)
 
 	assert.Equal(t, 4, b.Queue(1)) // won't trigger a batch
 


### PR DESCRIPTION
instead of constructor