### PR TITLE
Support delete actions in elastic writer

### DIFF
--- a/elastic/ops.go
+++ b/elastic/ops.go
@@ -95,6 +95,7 @@ func Bulk(ctx context.Context, client *elasticsearch.TypedClient, items []*Docum
 				slog.Debug("elasticsearch version conflict (ignored)", "index", items[i].Index, "id", items[i].ID, "version", items[i].Version)
 			} else if item.Status == 404 && items[i].Action == ActionDelete {
 				slog.Debug("elasticsearch delete of missing document (ignored)", "index", items[i].Index, "id", items[i].ID)
+				numWritten++
 			} else {
 				if item.Status == 429 || item.Status >= 500 {
 					slog.Error("retryable elasticsearch bulk failure", "index", items[i].Index, "action", items[i].Action, "status", item.Status)

--- a/elastic/ops.go
+++ b/elastic/ops.go
@@ -12,35 +12,61 @@ import (
 	"github.com/elastic/go-elasticsearch/v8/typedapi/types/enums/versiontype"
 )
 
-// Document is a document to be indexed in Elasticsearch.
+// Action is the bulk operation to perform on a document.
+type Action string
+
+const (
+	ActionIndex  Action = "index"
+	ActionDelete Action = "delete"
+)
+
+// Document is a document to be indexed in or deleted from Elasticsearch.
 type Document struct {
+	Action  Action          `json:"action,omitempty"`  // defaults to index
 	Index   string          `json:"index"`
 	ID      string          `json:"id"`
 	Routing string          `json:"routing"`
 	Version int64           `json:"version,omitempty"` // optional, if > 0 uses external versioning
-	Body    json.RawMessage `json:"body"`
+	Body    json.RawMessage `json:"body,omitempty"`    // required for index, ignored for delete
 }
 
-// BulkIndex sends a batch of documents to Elasticsearch using the index action.
-func BulkIndex(ctx context.Context, client *elasticsearch.TypedClient, items []*Document) (int, []*Document, error) {
+// Bulk sends a batch of documents to Elasticsearch, performing the action specified on each one.
+func Bulk(ctx context.Context, client *elasticsearch.TypedClient, items []*Document) (int, []*Document, error) {
 	if len(items) == 0 {
 		return 0, nil, nil
 	}
 
 	req := client.Bulk()
 	for _, item := range items {
-		op := types.IndexOperation{
-			Index_:  &item.Index,
-			Id_:     &item.ID,
-			Routing: &item.Routing,
-		}
-		if item.Version > 0 {
-			op.Version = &item.Version
-			vt := versiontype.External
-			op.VersionType = &vt
-		}
-		if err := req.IndexOp(op, item.Body); err != nil {
-			return 0, items, fmt.Errorf("error building bulk index operation: %w", err)
+		switch item.Action {
+		case ActionDelete:
+			op := types.DeleteOperation{
+				Index_:  &item.Index,
+				Id_:     &item.ID,
+				Routing: &item.Routing,
+			}
+			if item.Version > 0 {
+				op.Version = &item.Version
+				vt := versiontype.External
+				op.VersionType = &vt
+			}
+			if err := req.DeleteOp(op); err != nil {
+				return 0, items, fmt.Errorf("error building bulk delete operation: %w", err)
+			}
+		default: // "" or ActionIndex
+			op := types.IndexOperation{
+				Index_:  &item.Index,
+				Id_:     &item.ID,
+				Routing: &item.Routing,
+			}
+			if item.Version > 0 {
+				op.Version = &item.Version
+				vt := versiontype.External
+				op.VersionType = &vt
+			}
+			if err := req.IndexOp(op, item.Body); err != nil {
+				return 0, items, fmt.Errorf("error building bulk index operation: %w", err)
+			}
 		}
 	}
 
@@ -67,9 +93,11 @@ func BulkIndex(ctx context.Context, client *elasticsearch.TypedClient, items []*
 				numWritten++
 			} else if item.Status == 409 {
 				slog.Debug("elasticsearch version conflict (ignored)", "index", items[i].Index, "id", items[i].ID, "version", items[i].Version)
+			} else if item.Status == 404 && items[i].Action == ActionDelete {
+				slog.Debug("elasticsearch delete of missing document (ignored)", "index", items[i].Index, "id", items[i].ID)
 			} else {
 				if item.Status == 429 || item.Status >= 500 {
-					slog.Error("retryable elasticsearch bulk index failure", "index", items[i].Index, "status", item.Status)
+					slog.Error("retryable elasticsearch bulk failure", "index", items[i].Index, "action", items[i].Action, "status", item.Status)
 				} else {
 					errType, errReason := "", ""
 					if item.Error != nil {
@@ -78,7 +106,7 @@ func BulkIndex(ctx context.Context, client *elasticsearch.TypedClient, items []*
 							errReason = *item.Error.Reason
 						}
 					}
-					slog.Error("permanent elasticsearch bulk index failure", "index", items[i].Index, "status", item.Status, "error_type", errType, "error_reason", errReason)
+					slog.Error("permanent elasticsearch bulk failure", "index", items[i].Index, "action", items[i].Action, "status", item.Status, "error_type", errType, "error_reason", errReason)
 				}
 				unprocessed = append(unprocessed, items[i])
 			}

--- a/elastic/ops_test.go
+++ b/elastic/ops_test.go
@@ -7,24 +7,24 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBulkIndex(t *testing.T) {
+func TestBulk(t *testing.T) {
 	ctx := t.Context()
 
 	createTestIndex(t, testClient, "test-bulk")
 	defer deleteTestIndex(t, testClient, "test-bulk")
 
 	// empty batch is a no-op
-	numWritten, retryable, err := elastic.BulkIndex(ctx, testClient, []*elastic.Document{})
+	numWritten, retryable, err := elastic.Bulk(ctx, testClient, []*elastic.Document{})
 	assert.NoError(t, err)
 	assert.Equal(t, 0, numWritten)
 	assert.Nil(t, retryable)
 
-	// index some documents
-	numWritten, retryable, err = elastic.BulkIndex(ctx, testClient, []*elastic.Document{
+	// index some documents (empty action defaults to index)
+	numWritten, retryable, err = elastic.Bulk(ctx, testClient, []*elastic.Document{
 		{Index: "test-bulk", ID: "1", Routing: "org1", Body: []byte(`{"name": "Item 1", "count": 100}`)},
 		{Index: "test-bulk", ID: "2", Routing: "org1", Body: []byte(`{"name": "Item 2", "count": 200}`)},
-		{Index: "test-bulk", ID: "3", Routing: "org1", Body: []byte(`{"name": "Item 3", "count": 300}`)},
-		{Index: "test-bulk", ID: "4", Routing: "org1", Body: []byte(`{"name": "Item 4", "count": 400}`)},
+		{Action: elastic.ActionIndex, Index: "test-bulk", ID: "3", Routing: "org1", Body: []byte(`{"name": "Item 3", "count": 300}`)},
+		{Action: elastic.ActionIndex, Index: "test-bulk", ID: "4", Routing: "org1", Body: []byte(`{"name": "Item 4", "count": 400}`)},
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, 4, numWritten)
@@ -33,8 +33,44 @@ func TestBulkIndex(t *testing.T) {
 	refreshIndex(t, testClient, "test-bulk")
 	assertCount(t, testClient, "test-bulk", 4)
 
+	// delete some documents
+	numWritten, retryable, err = elastic.Bulk(ctx, testClient, []*elastic.Document{
+		{Action: elastic.ActionDelete, Index: "test-bulk", ID: "1", Routing: "org1"},
+		{Action: elastic.ActionDelete, Index: "test-bulk", ID: "2", Routing: "org1"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, numWritten)
+	assert.Empty(t, retryable)
+
+	refreshIndex(t, testClient, "test-bulk")
+	assertCount(t, testClient, "test-bulk", 2)
+
+	// deleting a missing document is idempotent and not retryable
+	numWritten, retryable, err = elastic.Bulk(ctx, testClient, []*elastic.Document{
+		{Action: elastic.ActionDelete, Index: "test-bulk", ID: "1", Routing: "org1"}, // already deleted
+		{Action: elastic.ActionDelete, Index: "test-bulk", ID: "3", Routing: "org1"}, // exists
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, numWritten)
+	assert.Empty(t, retryable)
+
+	refreshIndex(t, testClient, "test-bulk")
+	assertCount(t, testClient, "test-bulk", 1)
+
+	// mixed index and delete in one batch
+	numWritten, retryable, err = elastic.Bulk(ctx, testClient, []*elastic.Document{
+		{Action: elastic.ActionIndex, Index: "test-bulk", ID: "5", Routing: "org1", Body: []byte(`{"name": "Item 5", "count": 500}`)},
+		{Action: elastic.ActionDelete, Index: "test-bulk", ID: "4", Routing: "org1"},
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, 2, numWritten)
+	assert.Empty(t, retryable)
+
+	refreshIndex(t, testClient, "test-bulk")
+	assertCount(t, testClient, "test-bulk", 1)
+
 	// index with external versioning
-	numWritten, retryable, err = elastic.BulkIndex(ctx, testClient, []*elastic.Document{
+	numWritten, retryable, err = elastic.Bulk(ctx, testClient, []*elastic.Document{
 		{Index: "test-bulk", ID: "10", Routing: "org1", Version: 5, Body: []byte(`{"name": "Versioned 1", "count": 1000}`)},
 		{Index: "test-bulk", ID: "11", Routing: "org1", Version: 3, Body: []byte(`{"name": "Versioned 2", "count": 1100}`)},
 	})
@@ -43,10 +79,10 @@ func TestBulkIndex(t *testing.T) {
 	assert.Empty(t, retryable)
 
 	refreshIndex(t, testClient, "test-bulk")
-	assertCount(t, testClient, "test-bulk", 6)
+	assertCount(t, testClient, "test-bulk", 3)
 
 	// re-index with same or older version should get 409 conflicts (ignored)
-	numWritten, retryable, err = elastic.BulkIndex(ctx, testClient, []*elastic.Document{
+	numWritten, retryable, err = elastic.Bulk(ctx, testClient, []*elastic.Document{
 		{Index: "test-bulk", ID: "10", Routing: "org1", Version: 3, Body: []byte(`{"name": "Versioned 1 old", "count": 999}`)},  // older version
 		{Index: "test-bulk", ID: "11", Routing: "org1", Version: 3, Body: []byte(`{"name": "Versioned 2 same", "count": 999}`)}, // same version
 	})
@@ -55,7 +91,7 @@ func TestBulkIndex(t *testing.T) {
 	assert.Empty(t, retryable) // 409s are not retryable
 
 	// re-index with newer version should succeed
-	numWritten, retryable, err = elastic.BulkIndex(ctx, testClient, []*elastic.Document{
+	numWritten, retryable, err = elastic.Bulk(ctx, testClient, []*elastic.Document{
 		{Index: "test-bulk", ID: "10", Routing: "org1", Version: 10, Body: []byte(`{"name": "Versioned 1 new", "count": 2000}`)},
 	})
 	assert.NoError(t, err)
@@ -66,7 +102,7 @@ func TestBulkIndex(t *testing.T) {
 	createTestIndexStrict(t, testClient, "test-strict")
 	defer deleteTestIndex(t, testClient, "test-strict")
 
-	numWritten, retryable, err = elastic.BulkIndex(ctx, testClient, []*elastic.Document{
+	numWritten, retryable, err = elastic.Bulk(ctx, testClient, []*elastic.Document{
 		{Index: "test-strict", ID: "1", Routing: "org1", Body: []byte(`{"name": "Item 1"}`)},               // ok
 		{Index: "test-strict", ID: "2", Routing: "org1", Body: []byte(`{"name": "Item 2", "extra": true}`)}, // strict mapping violation
 	})
@@ -76,7 +112,7 @@ func TestBulkIndex(t *testing.T) {
 	assert.Equal(t, "2", retryable[0].ID)
 
 	// test with nil batch
-	numWritten, retryable, err = elastic.BulkIndex(ctx, testClient, nil)
+	numWritten, retryable, err = elastic.Bulk(ctx, testClient, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, numWritten)
 	assert.Nil(t, retryable)

--- a/elastic/spool.go
+++ b/elastic/spool.go
@@ -128,7 +128,7 @@ func (s *Spool) flush() error {
 			return fmt.Errorf("error loading spool file %s: %w", file.path, err)
 		}
 
-		_, unprocessed, err := BulkIndex(ctx, s.client, docs)
+		_, unprocessed, err := Bulk(ctx, s.client, docs)
 		if err != nil {
 			slog.Error("error flushing spooled elasticsearch batch", "error", err, "file", file.path)
 			continue

--- a/elastic/writer.go
+++ b/elastic/writer.go
@@ -70,7 +70,7 @@ func (w *Writer) Stats() (int64, int64) {
 func (w *Writer) flush(batch []*Document) {
 	ctx := context.TODO()
 
-	numWritten, unprocessed, err := BulkIndex(ctx, w.client, batch)
+	numWritten, unprocessed, err := Bulk(ctx, w.client, batch)
 	if err != nil {
 		slog.Error("error writing batch to elasticsearch", "count", len(batch), "error", err)
 		if unprocessed == nil {


### PR DESCRIPTION
## Summary
- Add `Action` field to `elastic.Document` with `ActionIndex` (default, preserves backward compat) and `ActionDelete` constants
- Rename `BulkIndex` → `Bulk` since it now handles both index and delete operations; writer and spool route through it transparently
- Treat status 404 on delete as idempotent (debug-logged, not retryable)

## Test plan
- [x] `go test -p=1 ./elastic/...` passes (new tests cover delete, mixed index+delete batches, and delete-of-missing-doc)
- [x] Full `go test -p=1 ./...` passes