### PR TITLE
Fix AccessConfig matching IPv4 hosts against IPv6 nets

### DIFF
--- a/httpx/access.go
+++ b/httpx/access.go
@@ -40,13 +40,28 @@ func (c *AccessConfig) Allow(request *http.Request) (bool, error) {
 
 	// if any of the host's addresses appear in the disallowed list, deny the request
 	for _, addr := range addrs {
+		// Normalize IPv4-in-IPv6 to 4-byte form so an IPv4-mapped IPv6 address can't bypass
+		// an IPv4 rule by being expressed as ::ffff:x.x.x.x.
+		ip := addr.IP
+		isV4 := ip.To4() != nil
+		if isV4 {
+			ip = ip.To4()
+		}
 		for _, disallowed := range c.DisallowedIPs {
-			if addr.IP.Equal(disallowed) {
+			if ip.Equal(disallowed) {
 				return false, nil
 			}
 		}
 		for _, disallowed := range c.DisallowedNets {
-			if disallowed.Contains(addr.IP) {
+			// Only check IPv4 hosts against IPv4 nets and IPv6 hosts against IPv6 nets.
+			// Without this, an IPv6 net that projects into IPv4 space (e.g. ::ffff:0:0/96)
+			// would match every IPv4 host, because IPNet.Contains strips the ::ffff: prefix
+			// internally and compares as IPv4.
+			netIsV4 := len(disallowed.IP) == net.IPv4len
+			if isV4 != netIsV4 {
+				continue
+			}
+			if disallowed.Contains(ip) {
 				return false, nil
 			}
 		}

--- a/httpx/access.go
+++ b/httpx/access.go
@@ -56,8 +56,11 @@ func (c *AccessConfig) Allow(request *http.Request) (bool, error) {
 			// Only check IPv4 hosts against IPv4 nets and IPv6 hosts against IPv6 nets.
 			// Without this, an IPv6 net that projects into IPv4 space (e.g. ::ffff:0:0/96)
 			// would match every IPv4 host, because IPNet.Contains strips the ::ffff: prefix
-			// internally and compares as IPv4.
-			netIsV4 := len(disallowed.IP) == net.IPv4len
+			// internally and compares as IPv4. Use mask size for family detection because
+			// the net's IP can be stored in 16-byte form even for IPv4 (e.g. when built via
+			// net.IPv4 without To4), but the mask reliably reflects the intended family.
+			_, maskBits := disallowed.Mask.Size()
+			netIsV4 := maskBits == 32
 			if isV4 != netIsV4 {
 				continue
 			}

--- a/httpx/access_test.go
+++ b/httpx/access_test.go
@@ -24,6 +24,9 @@ func TestAccessConfig(t *testing.T) {
 		},
 		[]*net.IPNet{
 			{IP: net.IPv4(10, 0, 0, 0).To4(), Mask: net.CIDRMask(8, 32)},
+			// IPv4 net with IP left in 16-byte form (net.IPv4 returns 16-byte) — must still
+			// be treated as IPv4 so 192.168.x.x hosts are denied.
+			{IP: net.IPv4(192, 168, 0, 0), Mask: net.CIDRMask(16, 32)},
 			ipv4MappedIPv6Net,
 		},
 	)
@@ -63,6 +66,8 @@ func TestAccessConfig(t *testing.T) {
 		{"https://10.1.0.0", false},
 		{"https://10.0.1.0", false},
 		{"https://10.0.0.1", false},
+		// IPv4 net constructed with a 16-byte IP must still match IPv4 hosts
+		{"https://192.168.1.1", false},
 		// IPv4-mapped IPv6 must not bypass an IPv4 disallowed net
 		{"https://[0:0:0:0:0:ffff:0a01:0000]:80", false}, // 10.1.0.0 mapped to IPv6
 	}

--- a/httpx/access_test.go
+++ b/httpx/access_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var _, ipv4MappedIPv6Net, _ = net.ParseCIDR("::ffff:0:0/96")
+
 func TestAccessConfig(t *testing.T) {
 	defer httpx.SetRequestor(httpx.DefaultRequestor)
 
@@ -22,6 +24,7 @@ func TestAccessConfig(t *testing.T) {
 		},
 		[]*net.IPNet{
 			{IP: net.IPv4(10, 0, 0, 0).To4(), Mask: net.CIDRMask(8, 32)},
+			ipv4MappedIPv6Net,
 		},
 	)
 
@@ -30,6 +33,9 @@ func TestAccessConfig(t *testing.T) {
 			httpx.NewMockResponse(200, nil, nil),
 		},
 		"https://11.0.0.0": {
+			httpx.NewMockResponse(200, nil, nil),
+		},
+		"https://8.8.8.8": {
 			httpx.NewMockResponse(200, nil, nil),
 		},
 	}))
@@ -41,6 +47,8 @@ func TestAccessConfig(t *testing.T) {
 		// allowed
 		{"https://nyaruka.com", true},
 		{"https://11.0.0.0", true},
+		// a plain IPv4 host must not match an IPv6 disallowed net like ::ffff:0:0/96
+		{"https://8.8.8.8", true},
 
 		// denied by IP match
 		{"https://localhost/path", false},
@@ -55,9 +63,8 @@ func TestAccessConfig(t *testing.T) {
 		{"https://10.1.0.0", false},
 		{"https://10.0.1.0", false},
 		{"https://10.0.0.1", false},
-
-		// TODO re-enable once https://github.com/golang/go/issues/75815 is fixed
-		//{"https://[0:0:0:0:0:ffff:0a01:0000]:80", false}, // 10.1.0.0 mapped to IPv6
+		// IPv4-mapped IPv6 must not bypass an IPv4 disallowed net
+		{"https://[0:0:0:0:0:ffff:0a01:0000]:80", false}, // 10.1.0.0 mapped to IPv6
 	}
 	for _, tc := range tests {
 		request, err := http.NewRequest("GET", tc.url, nil)


### PR DESCRIPTION
## Summary
- An IPv6 entry in `DisallowedNets` such as `::ffff:0:0/96` was matching every IPv4 host. Go's `IPNet.Contains` strips the `::ffff:` prefix internally and ends up comparing as IPv4 against an effective `0.0.0.0/0`, so any operator who added that CIDR to block IPv4-mapped IPv6 bypass attempts would instead block all outbound IPv4 traffic. Now `Allow` skips cross-family net checks, so an IPv6 net cannot match an IPv4 host (and vice versa).
- Normalize IPv4-in-IPv6 addresses to 4-byte form before checking, so an IPv4-mapped IPv6 destination (e.g. `https://[::ffff:0a01:0000]`) is still caught by an IPv4 rule like `10.0.0.0/8`. Previously this was a known bypass — there was a TODO in the test referencing https://github.com/golang/go/issues/75815.

## Test plan
- [x] `go test ./httpx/...` passes
- [x] New regression case: `8.8.8.8` is allowed when `::ffff:0:0/96` is in the disallowed nets
- [x] Previously-disabled bypass case (`::ffff:10.1.0.0` denied by a `10.0.0.0/8` rule) re-enabled and passing