### PR TITLE
httpx: add wrappable access-control transport

### DIFF
--- a/httpx/access.go
+++ b/httpx/access.go
@@ -106,6 +106,10 @@ func WithAccess(inner http.RoundTripper, access *AccessConfig) http.RoundTripper
 
 func (t *accessTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 	if err := t.access.check(request); err != nil {
+		// the http.RoundTripper contract requires the request body to be closed even on error paths
+		if request.Body != nil {
+			request.Body.Close()
+		}
 		return nil, err
 	}
 	return t.inner.RoundTrip(request)

--- a/httpx/access.go
+++ b/httpx/access.go
@@ -72,6 +72,45 @@ func (c *AccessConfig) Allow(request *http.Request) (bool, error) {
 	return true, nil
 }
 
+// check applies the access config to the request, returning ErrAccessConfig if the request is denied, or the
+// underlying error if the access check itself fails. A nil config permits everything.
+func (c *AccessConfig) check(request *http.Request) error {
+	if c == nil {
+		return nil
+	}
+	allowed, err := c.Allow(request)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return ErrAccessConfig
+	}
+	return nil
+}
+
+// accessTransport is an http.RoundTripper which enforces an AccessConfig before delegating to an inner transport.
+type accessTransport struct {
+	inner  http.RoundTripper
+	access *AccessConfig
+}
+
+// NewAccessTransport creates an http.RoundTripper which enforces the given access config before delegating to the
+// inner transport. A nil access config makes it a pass-through, so it's always safe to wrap. If inner is nil then
+// http.DefaultTransport is used.
+func NewAccessTransport(inner http.RoundTripper, access *AccessConfig) http.RoundTripper {
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	return &accessTransport{inner: inner, access: access}
+}
+
+func (t *accessTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	if err := t.access.check(request); err != nil {
+		return nil, err
+	}
+	return t.inner.RoundTrip(request)
+}
+
 // ParseNetworks parses a list of IPs and IP networks (written in CIDR notation)
 func ParseNetworks(addrs ...string) ([]net.IP, []*net.IPNet, error) {
 	ips := make([]net.IP, 0, len(addrs))

--- a/httpx/access.go
+++ b/httpx/access.go
@@ -94,10 +94,10 @@ type accessTransport struct {
 	access *AccessConfig
 }
 
-// NewAccessTransport creates an http.RoundTripper which enforces the given access config before delegating to the
-// inner transport. A nil access config makes it a pass-through, so it's always safe to wrap. If inner is nil then
+// WithAccess wraps an http.RoundTripper so that it enforces the given access config before delegating to the inner
+// transport. A nil access config makes it a pass-through, so it's always safe to wrap. If inner is nil then
 // http.DefaultTransport is used.
-func NewAccessTransport(inner http.RoundTripper, access *AccessConfig) http.RoundTripper {
+func WithAccess(inner http.RoundTripper, access *AccessConfig) http.RoundTripper {
 	if inner == nil {
 		inner = http.DefaultTransport
 	}

--- a/httpx/access_test.go
+++ b/httpx/access_test.go
@@ -1,6 +1,7 @@
 package httpx_test
 
 import (
+	"io"
 	"net"
 	"net/http"
 	"testing"
@@ -85,6 +86,14 @@ func TestAccessConfig(t *testing.T) {
 	}
 }
 
+// recordingBody is an io.ReadCloser which records whether it has been closed
+type recordingBody struct {
+	closed bool
+}
+
+func (b *recordingBody) Read(p []byte) (int, error) { return 0, io.EOF }
+func (b *recordingBody) Close() error               { b.closed = true; return nil }
+
 func TestAccessTransport(t *testing.T) {
 	access := httpx.NewAccessConfig(
 		30*time.Second,
@@ -97,7 +106,8 @@ func TestAccessTransport(t *testing.T) {
 		"https://8.8.8.8": {httpx.NewMockResponse(200, nil, nil)},
 	})
 	transport := httpx.WithAccess(inner, access)
-	req, _ := http.NewRequest("GET", "https://8.8.8.8", nil)
+	req, err := http.NewRequest("GET", "https://8.8.8.8", nil)
+	require.NoError(t, err)
 	resp, err := transport.RoundTrip(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
@@ -106,28 +116,55 @@ func TestAccessTransport(t *testing.T) {
 	// disallowed request returns ErrAccessConfig and never reaches the inner transport
 	inner = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{})
 	transport = httpx.WithAccess(inner, access)
-	req, _ = http.NewRequest("GET", "https://127.0.0.1", nil)
+	req, err = http.NewRequest("GET", "https://127.0.0.1", nil)
+	require.NoError(t, err)
 	resp, err = transport.RoundTrip(req)
 	assert.Equal(t, httpx.ErrAccessConfig, err)
 	assert.Nil(t, resp)
 	assert.Empty(t, inner.Requests())
 
-	// an error from Allow (here a DNS failure) is propagated as-is, not converted to ErrAccessConfig
+	// a denied request with a non-nil body must have that body closed (http.RoundTripper contract)
+	body := &recordingBody{}
 	inner = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{})
 	transport = httpx.WithAccess(inner, access)
-	req, _ = http.NewRequest("GET", "https://nonexistent.invalid", nil)
+	req, err = http.NewRequest("POST", "https://127.0.0.1", body)
+	require.NoError(t, err)
+	resp, err = transport.RoundTrip(req)
+	assert.Equal(t, httpx.ErrAccessConfig, err)
+	assert.Nil(t, resp)
+	assert.True(t, body.closed, "request body should be closed on the deny path")
+	assert.Empty(t, inner.Requests())
+
+	// an error from Allow (here a resolver timeout) is propagated as-is, not converted to ErrAccessConfig.
+	// A 1ns resolve timeout forces a deterministic error without depending on real DNS resolution.
+	timeoutAccess := httpx.NewAccessConfig(time.Nanosecond, []net.IP{net.ParseIP("127.0.0.1")}, nil)
+	inner = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{})
+	transport = httpx.WithAccess(inner, timeoutAccess)
+	req, err = http.NewRequest("GET", "https://example.com", nil)
+	require.NoError(t, err)
 	resp, err = transport.RoundTrip(req)
 	assert.Error(t, err)
 	assert.NotEqual(t, httpx.ErrAccessConfig, err)
 	assert.Nil(t, resp)
 	assert.Empty(t, inner.Requests())
 
+	// a nil inner transport falls back to http.DefaultTransport and the result is usable (here the request
+	// is denied before it would reach DefaultTransport, so no real network call is made)
+	transport = httpx.WithAccess(nil, access)
+	assert.NotNil(t, transport)
+	req, err = http.NewRequest("GET", "https://127.0.0.1", nil)
+	require.NoError(t, err)
+	resp, err = transport.RoundTrip(req)
+	assert.Equal(t, httpx.ErrAccessConfig, err)
+	assert.Nil(t, resp)
+
 	// a nil access config is a pass-through, even for an otherwise-denied host
 	inner = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
 		"https://127.0.0.1": {httpx.NewMockResponse(200, nil, nil)},
 	})
 	transport = httpx.WithAccess(inner, nil)
-	req, _ = http.NewRequest("GET", "https://127.0.0.1", nil)
+	req, err = http.NewRequest("GET", "https://127.0.0.1", nil)
+	require.NoError(t, err)
 	resp, err = transport.RoundTrip(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)

--- a/httpx/access_test.go
+++ b/httpx/access_test.go
@@ -85,6 +85,55 @@ func TestAccessConfig(t *testing.T) {
 	}
 }
 
+func TestAccessTransport(t *testing.T) {
+	access := httpx.NewAccessConfig(
+		30*time.Second,
+		[]net.IP{net.ParseIP("127.0.0.1")},
+		nil,
+	)
+
+	// allowed request delegates to the inner transport
+	inner := httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
+		"https://8.8.8.8": {httpx.NewMockResponse(200, nil, nil)},
+	})
+	transport := httpx.NewAccessTransport(inner, access)
+	req, _ := http.NewRequest("GET", "https://8.8.8.8", nil)
+	resp, err := transport.RoundTrip(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Len(t, inner.Requests(), 1)
+
+	// disallowed request returns ErrAccessConfig and never reaches the inner transport
+	inner = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{})
+	transport = httpx.NewAccessTransport(inner, access)
+	req, _ = http.NewRequest("GET", "https://127.0.0.1", nil)
+	resp, err = transport.RoundTrip(req)
+	assert.Equal(t, httpx.ErrAccessConfig, err)
+	assert.Nil(t, resp)
+	assert.Empty(t, inner.Requests())
+
+	// an error from Allow (here a DNS failure) is propagated as-is, not converted to ErrAccessConfig
+	inner = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{})
+	transport = httpx.NewAccessTransport(inner, access)
+	req, _ = http.NewRequest("GET", "https://nonexistent.invalid", nil)
+	resp, err = transport.RoundTrip(req)
+	assert.Error(t, err)
+	assert.NotEqual(t, httpx.ErrAccessConfig, err)
+	assert.Nil(t, resp)
+	assert.Empty(t, inner.Requests())
+
+	// a nil access config is a pass-through, even for an otherwise-denied host
+	inner = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
+		"https://127.0.0.1": {httpx.NewMockResponse(200, nil, nil)},
+	})
+	transport = httpx.NewAccessTransport(inner, nil)
+	req, _ = http.NewRequest("GET", "https://127.0.0.1", nil)
+	resp, err = transport.RoundTrip(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Len(t, inner.Requests(), 1)
+}
+
 func TestParseNetworkList(t *testing.T) {
 	privateNetwork1 := &net.IPNet{IP: net.IPv4(10, 0, 0, 0).To4(), Mask: net.CIDRMask(8, 32)}
 	privateNetwork2 := &net.IPNet{IP: net.IPv4(172, 16, 0, 0).To4(), Mask: net.CIDRMask(12, 32)}

--- a/httpx/access_test.go
+++ b/httpx/access_test.go
@@ -96,7 +96,7 @@ func TestAccessTransport(t *testing.T) {
 	inner := httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
 		"https://8.8.8.8": {httpx.NewMockResponse(200, nil, nil)},
 	})
-	transport := httpx.NewAccessTransport(inner, access)
+	transport := httpx.WithAccess(inner, access)
 	req, _ := http.NewRequest("GET", "https://8.8.8.8", nil)
 	resp, err := transport.RoundTrip(req)
 	assert.NoError(t, err)
@@ -105,7 +105,7 @@ func TestAccessTransport(t *testing.T) {
 
 	// disallowed request returns ErrAccessConfig and never reaches the inner transport
 	inner = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{})
-	transport = httpx.NewAccessTransport(inner, access)
+	transport = httpx.WithAccess(inner, access)
 	req, _ = http.NewRequest("GET", "https://127.0.0.1", nil)
 	resp, err = transport.RoundTrip(req)
 	assert.Equal(t, httpx.ErrAccessConfig, err)
@@ -114,7 +114,7 @@ func TestAccessTransport(t *testing.T) {
 
 	// an error from Allow (here a DNS failure) is propagated as-is, not converted to ErrAccessConfig
 	inner = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{})
-	transport = httpx.NewAccessTransport(inner, access)
+	transport = httpx.WithAccess(inner, access)
 	req, _ = http.NewRequest("GET", "https://nonexistent.invalid", nil)
 	resp, err = transport.RoundTrip(req)
 	assert.Error(t, err)
@@ -126,7 +126,7 @@ func TestAccessTransport(t *testing.T) {
 	inner = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
 		"https://127.0.0.1": {httpx.NewMockResponse(200, nil, nil)},
 	})
-	transport = httpx.NewAccessTransport(inner, nil)
+	transport = httpx.WithAccess(inner, nil)
 	req, _ = http.NewRequest("GET", "https://127.0.0.1", nil)
 	resp, err = transport.RoundTrip(req)
 	assert.NoError(t, err)

--- a/httpx/http.go
+++ b/httpx/http.go
@@ -30,14 +30,8 @@ func Do(client *http.Client, request *http.Request, retries *RetryConfig, access
 }
 
 func do(client *http.Client, request *http.Request, retries *RetryConfig, access *AccessConfig) (*http.Response, int, error) {
-	if access != nil {
-		allowed, err := access.Allow(request)
-		if err != nil {
-			return nil, 0, err
-		}
-		if !allowed {
-			return nil, 0, ErrAccessConfig
-		}
+	if err := access.check(request); err != nil {
+		return nil, 0, err
 	}
 
 	var response *http.Response


### PR DESCRIPTION
## What

Adds `httpx.WithAccess(inner http.RoundTripper, access *AccessConfig) http.RoundTripper` — an access-enforcing `http.RoundTripper` that applies an `*AccessConfig` before delegating to an inner transport:

- if `AccessConfig.Allow(req)` returns an error, that error is returned,
- if it returns `false`, `ErrAccessConfig` is returned,
- otherwise the request is delegated to the inner transport.

A nil `*AccessConfig` is a pass-through (delegates unconditionally), so it's always safe to wrap. If `inner` is nil, `http.DefaultTransport` is used.

The `With*` name (rather than `New*`) is deliberate: this is a decorator — same type in, same type out (`RoundTripper -> RoundTripper`) — so it reads as composition, and it sets the house style for the tracing/mock wrappers to follow.

This mirrors the access check that already lives inside `do()`. To avoid two copies of the allow/deny branch, the decision is factored into a small nil-safe helper (`(*AccessConfig).check`) that both `do()` and the new transport call. The `do()` rewrite is behavior-preserving (same error values, same return semantics) — the nil-receiver case reproduces the old `if access != nil` guard.

## Why — broader direction

This is the first building block of an incremental, backwards-compatible refactor of `httpx`. Today the package's cross-cutting concerns (access control, mocking, tracing) are bundled inside the `do()`/`DoTrace()` choke point, so anything that makes HTTP calls *without* going through `httpx.Do`/`DoTrace` — e.g. third-party SDK clients handed a plain `*http.Client` — gets none of them.

The goal is to express access / tracing / mocking as composable `http.RoundTripper`s so that **any** `*http.Client` (including SDK-owned ones) can opt in by wrapping its transport, with `Do`/`DoTrace`/`SetRequestor` becoming thin backwards-compatible shims over that chain. This PR delivers only the access-control transport; tracing and mock transports come later (likely as `WithTracing` / `WithMock`).

## Scope / compatibility

- Purely additive and backwards compatible — no exported signatures of `Do`, `DoTrace`, `SetRequestor`, `AccessConfig`, or `ErrAccessConfig` change.
- New unit tests cover: allowed request delegates to inner, disallowed request returns `ErrAccessConfig` (and never reaches inner), an `Allow` error is propagated as-is, and a nil config is a pass-through.
- Full `httpx` test suite and `go vet ./...` pass.