### PR TITLE
httpx: add wrappable mocking transport

### DIFF
--- a/httpx/mock.go
+++ b/httpx/mock.go
@@ -147,12 +147,12 @@ func MockIgnoreLocal() MockOption {
 // WithMocking wraps an http.RoundTripper so that requests matching one of the given mocks are answered from the
 // mock instead of being sent. If inner is nil then http.DefaultTransport is used. By default a request with no
 // matching mock panics, mirroring MockRequestor; pass MockPassthrough to instead delegate such requests to the
-// inner transport.
+// inner transport. The mocks map is copied, so the caller's map is never consumed and can be safely reused.
 func WithMocking(inner http.RoundTripper, mocks map[string][]*MockResponse, opts ...MockOption) *MockTransport {
 	if inner == nil {
 		inner = http.DefaultTransport
 	}
-	t := &MockTransport{inner: inner, mocks: mocks}
+	t := &MockTransport{inner: inner, mocks: maps.Clone(mocks)}
 	for _, opt := range opts {
 		opt(t)
 	}

--- a/httpx/mock.go
+++ b/httpx/mock.go
@@ -106,6 +106,57 @@ func (r *MockRequestor) UnmarshalJSON(data []byte) error {
 
 var _ Requestor = (*MockRequestor)(nil)
 
+// hasMock returns whether there is an unused mocked response available for the given request
+func (r *MockRequestor) hasMock(request *http.Request) bool {
+	url := request.URL.String()
+	match := stringsx.GlobSelect(url, slices.Collect(maps.Keys(r.mocks))...)
+	return len(r.mocks[match]) > 0
+}
+
+// mockTransport is an http.RoundTripper which answers requests from a MockRequestor, delegating to an inner
+// transport for requests it doesn't handle.
+type mockTransport struct {
+	inner       http.RoundTripper
+	mocks       *MockRequestor
+	passthrough bool
+}
+
+// MockOption configures a mocking transport created with WithMocking.
+type MockOption func(*mockTransport)
+
+// MockPassthrough makes a mocking transport delegate a request with no matching mock to the inner transport
+// instead of panicking (the default).
+func MockPassthrough() MockOption {
+	return func(t *mockTransport) { t.passthrough = true }
+}
+
+// WithMocking wraps an http.RoundTripper so that requests matching one of the mocks are answered from the mock
+// instead of being sent. A nil *MockRequestor is a pass-through, so it's always safe to wrap. If inner is nil then
+// http.DefaultTransport is used. By default a request with no matching mock panics, mirroring MockRequestor; pass
+// MockPassthrough to instead delegate such requests to the inner transport.
+func WithMocking(inner http.RoundTripper, mocks *MockRequestor, opts ...MockOption) http.RoundTripper {
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	t := &mockTransport{inner: inner, mocks: mocks}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
+}
+
+func (t *mockTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	// fall through to the inner transport for a nil mock, an ignored local request, or - in passthrough mode -
+	// a request with no matching mock
+	if t.mocks == nil || (t.mocks.ignoreLocal && isLocalRequest(request)) {
+		return t.inner.RoundTrip(request)
+	}
+	if t.passthrough && !t.mocks.hasMock(request) {
+		return t.inner.RoundTrip(request)
+	}
+	return t.mocks.RoundTrip(request)
+}
+
 type MockResponse struct {
 	Status       int
 	Headers      map[string]string

--- a/httpx/mock.go
+++ b/httpx/mock.go
@@ -45,24 +45,9 @@ func (r *MockRequestor) Do(client *http.Client, request *http.Request) (*http.Re
 func (r *MockRequestor) RoundTrip(request *http.Request) (*http.Response, error) {
 	r.requests = append(r.requests, request)
 
-	url := request.URL.String()
-
-	// find the most specific match against this URL
-	match := stringsx.GlobSelect(url, slices.Collect(maps.Keys(r.mocks))...)
-	mockedResponses := r.mocks[match]
-
-	if len(mockedResponses) == 0 {
-		panic(fmt.Sprintf("missing mock for URL %s", url))
-	}
-
-	// pop the next mocked response for this URL
-	mocked := mockedResponses[0]
-	remaining := mockedResponses[1:]
-
-	if len(remaining) > 0 {
-		r.mocks[match] = remaining
-	} else {
-		delete(r.mocks, match)
+	mocked := takeMock(r.mocks, request)
+	if mocked == nil {
+		panic(fmt.Sprintf("missing mock for URL %s", request.URL.String()))
 	}
 
 	if mocked.Status == 0 {
@@ -79,12 +64,7 @@ func (r *MockRequestor) Requests() []*http.Request {
 
 // HasUnused returns true if there are unused mocks leftover
 func (r *MockRequestor) HasUnused() bool {
-	for _, mocks := range r.mocks {
-		if len(mocks) > 0 {
-			return true
-		}
-	}
-	return false
+	return hasUnusedMocks(r.mocks)
 }
 
 // Clone returns a clone of this requestor
@@ -106,56 +86,114 @@ func (r *MockRequestor) UnmarshalJSON(data []byte) error {
 
 var _ Requestor = (*MockRequestor)(nil)
 
-// hasMock returns whether there is an unused mocked response available for the given request
-func (r *MockRequestor) hasMock(request *http.Request) bool {
+// takeMock pops the next mocked response matching the request's URL, mutating mocks. Returns nil if none match.
+func takeMock(mocks map[string][]*MockResponse, request *http.Request) *MockResponse {
 	url := request.URL.String()
-	match := stringsx.GlobSelect(url, slices.Collect(maps.Keys(r.mocks))...)
-	return len(r.mocks[match]) > 0
+
+	// find the most specific match against this URL
+	match := stringsx.GlobSelect(url, slices.Collect(maps.Keys(mocks))...)
+	mockedResponses := mocks[match]
+	if len(mockedResponses) == 0 {
+		return nil
+	}
+
+	// pop the next mocked response for this URL
+	mocked := mockedResponses[0]
+	remaining := mockedResponses[1:]
+	if len(remaining) > 0 {
+		mocks[match] = remaining
+	} else {
+		delete(mocks, match)
+	}
+
+	return mocked
 }
 
-// mockTransport is an http.RoundTripper which answers requests from a MockRequestor, delegating to an inner
-// transport for requests it doesn't handle.
-type mockTransport struct {
+// hasUnusedMocks returns whether any unused mocked responses remain
+func hasUnusedMocks(mocks map[string][]*MockResponse) bool {
+	for _, ms := range mocks {
+		if len(ms) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// MockTransport is an http.RoundTripper which answers requests from a set of mocked responses, delegating to an
+// inner transport for requests it doesn't handle. It's intended to be the composable replacement for MockRequestor.
+type MockTransport struct {
 	inner       http.RoundTripper
-	mocks       *MockRequestor
+	mocks       map[string][]*MockResponse
+	requests    []*http.Request
+	ignoreLocal bool
 	passthrough bool
 }
 
-// MockOption configures a mocking transport created with WithMocking.
-type MockOption func(*mockTransport)
+// MockOption configures a MockTransport created with WithMocking.
+type MockOption func(*MockTransport)
 
 // MockPassthrough makes a mocking transport delegate a request with no matching mock to the inner transport
 // instead of panicking (the default).
 func MockPassthrough() MockOption {
-	return func(t *mockTransport) { t.passthrough = true }
+	return func(t *MockTransport) { t.passthrough = true }
 }
 
-// WithMocking wraps an http.RoundTripper so that requests matching one of the mocks are answered from the mock
-// instead of being sent. A nil *MockRequestor is a pass-through, so it's always safe to wrap. If inner is nil then
-// http.DefaultTransport is used. By default a request with no matching mock panics, mirroring MockRequestor; pass
-// MockPassthrough to instead delegate such requests to the inner transport.
-func WithMocking(inner http.RoundTripper, mocks *MockRequestor, opts ...MockOption) http.RoundTripper {
+// MockIgnoreLocal makes a mocking transport delegate requests to localhost to the inner transport rather than
+// trying to mock them.
+func MockIgnoreLocal() MockOption {
+	return func(t *MockTransport) { t.ignoreLocal = true }
+}
+
+// WithMocking wraps an http.RoundTripper so that requests matching one of the given mocks are answered from the
+// mock instead of being sent. If inner is nil then http.DefaultTransport is used. By default a request with no
+// matching mock panics, mirroring MockRequestor; pass MockPassthrough to instead delegate such requests to the
+// inner transport.
+func WithMocking(inner http.RoundTripper, mocks map[string][]*MockResponse, opts ...MockOption) *MockTransport {
 	if inner == nil {
 		inner = http.DefaultTransport
 	}
-	t := &mockTransport{inner: inner, mocks: mocks}
+	t := &MockTransport{inner: inner, mocks: mocks}
 	for _, opt := range opts {
 		opt(t)
 	}
 	return t
 }
 
-func (t *mockTransport) RoundTrip(request *http.Request) (*http.Response, error) {
-	// fall through to the inner transport for a nil mock, an ignored local request, or - in passthrough mode -
-	// a request with no matching mock
-	if t.mocks == nil || (t.mocks.ignoreLocal && isLocalRequest(request)) {
+func (t *MockTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	// delegate local requests to the inner transport when ignoring local
+	if t.ignoreLocal && isLocalRequest(request) {
 		return t.inner.RoundTrip(request)
 	}
-	if t.passthrough && !t.mocks.hasMock(request) {
-		return t.inner.RoundTrip(request)
+
+	mocked := takeMock(t.mocks, request)
+	if mocked == nil {
+		// no matching mock - either pass through to the inner transport or panic to catch the unexpected request
+		if t.passthrough {
+			return t.inner.RoundTrip(request)
+		}
+		panic(fmt.Sprintf("missing mock for URL %s", request.URL.String()))
 	}
-	return t.mocks.RoundTrip(request)
+
+	t.requests = append(t.requests, request)
+
+	if mocked.Status == 0 {
+		return nil, errors.New("unable to connect to server")
+	}
+
+	return mocked.Make(request), nil
 }
+
+// Requests returns the requests that were answered from mocks
+func (t *MockTransport) Requests() []*http.Request {
+	return t.requests
+}
+
+// HasUnused returns true if there are unused mocks leftover
+func (t *MockTransport) HasUnused() bool {
+	return hasUnusedMocks(t.mocks)
+}
+
+var _ http.RoundTripper = (*MockTransport)(nil)
 
 type MockResponse struct {
 	Status       int

--- a/httpx/mock_test.go
+++ b/httpx/mock_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nyaruka/gocommon/jsonx"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMockRequestor(t *testing.T) {
@@ -108,6 +109,94 @@ func TestMockRequestor(t *testing.T) {
 	response, err = httpx.Do(http.DefaultClient, req9, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 200, response.StatusCode)
+}
+
+func TestMockTransport(t *testing.T) {
+	// a matched request is answered from the mock and recorded
+	mocks := httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
+		"https://temba.io": {httpx.NewMockResponse(200, nil, []byte("hi"))},
+	})
+	transport := httpx.WithMocking(http.DefaultTransport, mocks)
+	req, err := http.NewRequest("GET", "https://temba.io", nil)
+	require.NoError(t, err)
+	resp, err := transport.RoundTrip(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Len(t, mocks.Requests(), 1)
+
+	// a nil inner transport falls back to http.DefaultTransport; the mock answers so it's never called
+	mocks = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
+		"https://temba.io": {httpx.NewMockResponse(200, nil, nil)},
+	})
+	transport = httpx.WithMocking(nil, mocks)
+	assert.NotNil(t, transport)
+	req, err = http.NewRequest("GET", "https://temba.io", nil)
+	require.NoError(t, err)
+	resp, err = transport.RoundTrip(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	// by default a request with no matching mock panics
+	mocks = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{})
+	transport = httpx.WithMocking(http.DefaultTransport, mocks)
+	req, err = http.NewRequest("GET", "https://temba.io", nil)
+	require.NoError(t, err)
+	assert.Panics(t, func() { transport.RoundTrip(req) })
+
+	// with MockPassthrough, a request with no matching mock is delegated to the inner transport
+	inner := httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
+		"https://temba.io": {httpx.NewMockResponse(418, nil, nil)},
+	})
+	mocks = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{})
+	transport = httpx.WithMocking(inner, mocks, httpx.MockPassthrough())
+	req, err = http.NewRequest("GET", "https://temba.io", nil)
+	require.NoError(t, err)
+	resp, err = transport.RoundTrip(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 418, resp.StatusCode)
+	assert.Len(t, inner.Requests(), 1)
+	assert.Empty(t, mocks.Requests())
+
+	// a matched request is still answered from the mock even in passthrough mode
+	inner = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{})
+	mocks = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
+		"https://temba.io": {httpx.NewMockResponse(200, nil, nil)},
+	})
+	transport = httpx.WithMocking(inner, mocks, httpx.MockPassthrough())
+	req, err = http.NewRequest("GET", "https://temba.io", nil)
+	require.NoError(t, err)
+	resp, err = transport.RoundTrip(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Len(t, mocks.Requests(), 1)
+	assert.Empty(t, inner.Requests())
+
+	// with ignoreLocal set, a local request is delegated to the inner transport rather than mocked
+	inner = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
+		"http://localhost/health": {httpx.NewMockResponse(200, nil, nil)},
+	})
+	mocks = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{})
+	mocks.SetIgnoreLocal(true)
+	transport = httpx.WithMocking(inner, mocks)
+	req, err = http.NewRequest("GET", "http://localhost/health", nil)
+	require.NoError(t, err)
+	resp, err = transport.RoundTrip(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Len(t, inner.Requests(), 1)
+	assert.Empty(t, mocks.Requests())
+
+	// a nil mock requestor is a pass-through to the inner transport
+	inner = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
+		"https://temba.io": {httpx.NewMockResponse(202, nil, nil)},
+	})
+	transport = httpx.WithMocking(inner, nil)
+	req, err = http.NewRequest("GET", "https://temba.io", nil)
+	require.NoError(t, err)
+	resp, err = transport.RoundTrip(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 202, resp.StatusCode)
+	assert.Len(t, inner.Requests(), 1)
 }
 
 func TestMockRequestorMarshaling(t *testing.T) {

--- a/httpx/mock_test.go
+++ b/httpx/mock_test.go
@@ -113,90 +113,82 @@ func TestMockRequestor(t *testing.T) {
 
 func TestMockTransport(t *testing.T) {
 	// a matched request is answered from the mock and recorded
-	mocks := httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
+	mt := httpx.WithMocking(http.DefaultTransport, map[string][]*httpx.MockResponse{
 		"https://temba.io": {httpx.NewMockResponse(200, nil, []byte("hi"))},
 	})
-	transport := httpx.WithMocking(http.DefaultTransport, mocks)
 	req, err := http.NewRequest("GET", "https://temba.io", nil)
 	require.NoError(t, err)
-	resp, err := transport.RoundTrip(req)
+	resp, err := mt.RoundTrip(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
-	assert.Len(t, mocks.Requests(), 1)
+	assert.Len(t, mt.Requests(), 1)
+	assert.False(t, mt.HasUnused())
 
-	// a nil inner transport falls back to http.DefaultTransport; the mock answers so it's never called
-	mocks = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
-		"https://temba.io": {httpx.NewMockResponse(200, nil, nil)},
+	// a mocked connection error is returned as an error
+	mt = httpx.WithMocking(http.DefaultTransport, map[string][]*httpx.MockResponse{
+		"https://temba.io": {httpx.MockConnectionError},
 	})
-	transport = httpx.WithMocking(nil, mocks)
-	assert.NotNil(t, transport)
 	req, err = http.NewRequest("GET", "https://temba.io", nil)
 	require.NoError(t, err)
-	resp, err = transport.RoundTrip(req)
+	resp, err = mt.RoundTrip(req)
+	assert.EqualError(t, err, "unable to connect to server")
+	assert.Nil(t, resp)
+
+	// a nil inner transport falls back to http.DefaultTransport; the mock answers so it's never called
+	mt = httpx.WithMocking(nil, map[string][]*httpx.MockResponse{
+		"https://temba.io": {httpx.NewMockResponse(200, nil, nil)},
+	})
+	assert.NotNil(t, mt)
+	req, err = http.NewRequest("GET", "https://temba.io", nil)
+	require.NoError(t, err)
+	resp, err = mt.RoundTrip(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 
 	// by default a request with no matching mock panics
-	mocks = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{})
-	transport = httpx.WithMocking(http.DefaultTransport, mocks)
+	mt = httpx.WithMocking(http.DefaultTransport, nil)
 	req, err = http.NewRequest("GET", "https://temba.io", nil)
 	require.NoError(t, err)
-	assert.Panics(t, func() { transport.RoundTrip(req) })
+	assert.Panics(t, func() { mt.RoundTrip(req) })
 
 	// with MockPassthrough, a request with no matching mock is delegated to the inner transport
-	inner := httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
+	inner := httpx.WithMocking(http.DefaultTransport, map[string][]*httpx.MockResponse{
 		"https://temba.io": {httpx.NewMockResponse(418, nil, nil)},
 	})
-	mocks = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{})
-	transport = httpx.WithMocking(inner, mocks, httpx.MockPassthrough())
+	mt = httpx.WithMocking(inner, nil, httpx.MockPassthrough())
 	req, err = http.NewRequest("GET", "https://temba.io", nil)
 	require.NoError(t, err)
-	resp, err = transport.RoundTrip(req)
+	resp, err = mt.RoundTrip(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 418, resp.StatusCode)
 	assert.Len(t, inner.Requests(), 1)
-	assert.Empty(t, mocks.Requests())
+	assert.Empty(t, mt.Requests())
 
 	// a matched request is still answered from the mock even in passthrough mode
-	inner = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{})
-	mocks = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
+	inner = httpx.WithMocking(http.DefaultTransport, map[string][]*httpx.MockResponse{})
+	mt = httpx.WithMocking(inner, map[string][]*httpx.MockResponse{
 		"https://temba.io": {httpx.NewMockResponse(200, nil, nil)},
-	})
-	transport = httpx.WithMocking(inner, mocks, httpx.MockPassthrough())
+	}, httpx.MockPassthrough())
 	req, err = http.NewRequest("GET", "https://temba.io", nil)
 	require.NoError(t, err)
-	resp, err = transport.RoundTrip(req)
+	resp, err = mt.RoundTrip(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
-	assert.Len(t, mocks.Requests(), 1)
+	assert.Len(t, mt.Requests(), 1)
 	assert.Empty(t, inner.Requests())
 
-	// with ignoreLocal set, a local request is delegated to the inner transport rather than mocked
-	inner = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
+	// with MockIgnoreLocal, a local request is delegated to the inner transport rather than mocked
+	inner = httpx.WithMocking(http.DefaultTransport, map[string][]*httpx.MockResponse{
 		"http://localhost/health": {httpx.NewMockResponse(200, nil, nil)},
 	})
-	mocks = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{})
-	mocks.SetIgnoreLocal(true)
-	transport = httpx.WithMocking(inner, mocks)
+	mt = httpx.WithMocking(inner, map[string][]*httpx.MockResponse{}, httpx.MockIgnoreLocal())
 	req, err = http.NewRequest("GET", "http://localhost/health", nil)
 	require.NoError(t, err)
-	resp, err = transport.RoundTrip(req)
+	resp, err = mt.RoundTrip(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	assert.Len(t, inner.Requests(), 1)
-	assert.Empty(t, mocks.Requests())
-
-	// a nil mock requestor is a pass-through to the inner transport
-	inner = httpx.NewMockRequestor(map[string][]*httpx.MockResponse{
-		"https://temba.io": {httpx.NewMockResponse(202, nil, nil)},
-	})
-	transport = httpx.WithMocking(inner, nil)
-	req, err = http.NewRequest("GET", "https://temba.io", nil)
-	require.NoError(t, err)
-	resp, err = transport.RoundTrip(req)
-	assert.NoError(t, err)
-	assert.Equal(t, 202, resp.StatusCode)
-	assert.Len(t, inner.Requests(), 1)
+	assert.Empty(t, mt.Requests())
 }
 
 func TestMockRequestorMarshaling(t *testing.T) {

--- a/httpx/mock_test.go
+++ b/httpx/mock_test.go
@@ -124,6 +124,18 @@ func TestMockTransport(t *testing.T) {
 	assert.Len(t, mt.Requests(), 1)
 	assert.False(t, mt.HasUnused())
 
+	// the caller's map is copied, not consumed - so it can be safely reused across runs without Clone()
+	original := map[string][]*httpx.MockResponse{
+		"https://temba.io": {httpx.NewMockResponse(200, nil, nil)},
+	}
+	mt = httpx.WithMocking(http.DefaultTransport, original)
+	req, err = http.NewRequest("GET", "https://temba.io", nil)
+	require.NoError(t, err)
+	_, err = mt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.False(t, mt.HasUnused())                    // the transport's copy is exhausted
+	assert.Len(t, original["https://temba.io"], 1)     // but the caller's map is untouched
+
 	// a mocked connection error is returned as an error
 	mt = httpx.WithMocking(http.DefaultTransport, map[string][]*httpx.MockResponse{
 		"https://temba.io": {httpx.MockConnectionError},


### PR DESCRIPTION
## What

Adds `httpx.WithMocking(inner http.RoundTripper, mocks map[string][]*MockResponse, opts ...MockOption) *MockTransport` — a mocking `http.RoundTripper` that answers requests from a set of mocked responses and otherwise delegates to an inner transport. This is the second composable building block after `WithAccess`.

Key design point: `WithMocking` takes the **mocks map directly** (not a `*MockRequestor`) and returns a concrete `*MockTransport` that owns the mocks, the request log, and the match/pop logic, exposing `Requests()` and `HasUnused()`. This is deliberate — `MockTransport` is intended to become the composable replacement for `MockRequestor`, so the transport (not a separate requestor object) is the introspectable mock primitive. (Checked the sibling repos: `Requests()`/`HasUnused()` are the only introspection methods anyone uses.)

- If `inner` is nil, `http.DefaultTransport` is used.
- The mocks map is **copied defensively**, so the caller's map is never consumed and can be reused across runs without `Clone()`. (Matching pops responses out of the map; today callers `Clone()` a template to work around that — this removes the footgun.)
- Shared `takeMock` / `hasUnusedMocks` helpers are factored out so `MockRequestor` and `MockTransport` don't duplicate the glob-matching/popping logic (and `MockRequestor.RoundTrip` is now a thin wrapper over the shared helper — behavior unchanged).

### Configurable behavior (functional options)

- **default** — a request with no matching mock panics, mirroring `MockRequestor`'s safety net so unexpected calls fail loudly in tests.
- **`MockPassthrough()`** — delegate an unmatched request to the inner transport instead, so you can mock some endpoints while others reach the real backend.
- **`MockIgnoreLocal()`** — delegate localhost requests to the inner transport (parity with `MockRequestor.SetIgnoreLocal`).

I used functional options (`MockOption`) so the common case stays a clean call and the knob set can grow. Happy to switch to a required mode enum if reviewers prefer the choice be explicit at every call site.

## Why — broader direction

This continues the incremental, backwards-compatible move toward expressing `httpx`'s cross-cutting concerns (access control, mocking, tracing) as composable `http.RoundTripper`s, so that **any** `*http.Client` — including SDK-owned clients handed a plain `*http.Client` that never goes through `httpx.Do`/`DoTrace` — can opt into them by wrapping its transport. With `WithAccess` (merged) and `WithMocking` (this PR), an SDK client's requests can now be caught by a mock in tests:

```go
mock := httpx.WithMocking(client.Transport, mocks)
client.Transport = httpx.WithAccess(mock, access)
// later: mock.Requests(), mock.HasUnused()
```

`MockTransport` is positioned to **eventually replace `MockRequestor`** entirely. The real lever for that is the `SetRequestor`/`do()` path (≈40 call sites in goflow/courier set a global requestor; none wrap a client transport), which would be reframed to build a transport chain internally — at which point the global mock becomes a `MockTransport` under the hood and `MockRequestor` can be deleted. `MockRequestor` is left in place for now; this PR only stops `WithMocking` from depending on it.

Tracing (`WithTracing`) is the next building block; the final step is making `Do`/`DoTrace`/`SetRequestor` thin shims over the transport chain.

## Scope / compatibility

- Purely additive and backwards compatible — no exported signatures change; `do()`/`SetRequestor`/`MockRequestor` are untouched (only an internal, behavior-preserving refactor of `MockRequestor.RoundTrip`/`HasUnused` onto shared helpers).
- New unit tests cover: matched request answered/recorded; `HasUnused`; defensive map-copy (caller's map not consumed); mocked connection error; nil-inner fallback to `http.DefaultTransport`; unmatched panics by default; `MockPassthrough` delegates unmatched while still answering matched; `MockIgnoreLocal` delegates local requests.
- Full `httpx` test suite and `go vet ./...` pass.