### PR TITLE
httpx: add wrappable tracing transport

### DIFF
--- a/httpx/http.go
+++ b/httpx/http.go
@@ -156,6 +156,76 @@ func DoTrace(client *http.Client, request *http.Request, retries *RetryConfig, a
 	return trace, nil
 }
 
+// TracingTransport is an http.RoundTripper which captures a Trace of each request and response, delegating to an
+// inner transport. The response body is buffered so that it remains readable by the caller.
+type TracingTransport struct {
+	inner        http.RoundTripper
+	maxBodyBytes int
+	traces       []*Trace
+}
+
+// WithTracing wraps an http.RoundTripper so that each request and response is captured as a *Trace, retrievable via
+// Traces(). The response body is buffered so it remains readable by the caller; at most maxBodyBytes of it are
+// captured into the trace (a value <= 0 captures the entire body). If inner is nil then http.DefaultTransport is used.
+func WithTracing(inner http.RoundTripper, maxBodyBytes int) *TracingTransport {
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	return &TracingTransport{inner: inner, maxBodyBytes: maxBodyBytes}
+}
+
+func (t *TracingTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	requestTrace, err := httputil.DumpRequestOut(request, true)
+	if err != nil {
+		return nil, err
+	}
+
+	trace := &Trace{
+		Request:      request,
+		RequestTrace: requestTrace,
+		StartTime:    dates.Now(),
+	}
+	t.traces = append(t.traces, trace)
+	defer func() { trace.EndTime = dates.Now() }()
+
+	response, err := t.inner.RoundTrip(request)
+	trace.Response = response
+	if err != nil {
+		return response, err
+	}
+
+	// dump the response trace without the body, which we capture separately
+	responseTrace, err := httputil.DumpResponse(response, false)
+	if err != nil {
+		return response, err
+	}
+	trace.ResponseTrace = responseTrace
+
+	// read the full body so we can both capture it and hand a readable copy back to the caller
+	body, err := io.ReadAll(response.Body)
+	response.Body.Close()
+	if err != nil {
+		return response, err
+	}
+	response.Body = io.NopCloser(bytes.NewReader(body))
+
+	// capture up to maxBodyBytes of the body into the trace
+	if t.maxBodyBytes > 0 && len(body) > t.maxBodyBytes {
+		trace.ResponseBody = body[:t.maxBodyBytes]
+	} else {
+		trace.ResponseBody = body
+	}
+
+	return response, nil
+}
+
+// Traces returns the traces captured so far
+func (t *TracingTransport) Traces() []*Trace {
+	return t.traces
+}
+
+var _ http.RoundTripper = (*TracingTransport)(nil)
+
 // NewRequest is a convenience method to create a request with the given context and headers
 func NewRequest(ctx context.Context, method string, url string, body io.Reader, headers map[string]string) (*http.Request, error) {
 	r, err := http.NewRequestWithContext(ctx, method, url, body)

--- a/httpx/http.go
+++ b/httpx/http.go
@@ -9,7 +9,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httputil"
+	"slices"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -157,10 +159,12 @@ func DoTrace(client *http.Client, request *http.Request, retries *RetryConfig, a
 }
 
 // TracingTransport is an http.RoundTripper which captures a Trace of each request and response, delegating to an
-// inner transport. The response body is buffered so that it remains readable by the caller.
+// inner transport. The response body is buffered so that it remains readable by the caller. It is safe for
+// concurrent use by multiple goroutines, as the http.RoundTripper contract requires.
 type TracingTransport struct {
 	inner        http.RoundTripper
 	maxBodyBytes int
+	mutex        sync.Mutex
 	traces       []*Trace
 }
 
@@ -177,6 +181,10 @@ func WithTracing(inner http.RoundTripper, maxBodyBytes int) *TracingTransport {
 func (t *TracingTransport) RoundTrip(request *http.Request) (*http.Response, error) {
 	requestTrace, err := httputil.DumpRequestOut(request, true)
 	if err != nil {
+		// the http.RoundTripper contract requires the request body to be closed even on error paths
+		if request.Body != nil {
+			request.Body.Close()
+		}
 		return nil, err
 	}
 
@@ -185,46 +193,58 @@ func (t *TracingTransport) RoundTrip(request *http.Request) (*http.Response, err
 		RequestTrace: requestTrace,
 		StartTime:    dates.Now(),
 	}
+	t.mutex.Lock()
 	t.traces = append(t.traces, trace)
+	t.mutex.Unlock()
 	defer func() { trace.EndTime = dates.Now() }()
 
 	response, err := t.inner.RoundTrip(request)
 	trace.Response = response
 	if err != nil {
-		return response, err
+		// the inner transport failed to obtain a response
+		return nil, err
 	}
 
-	// dump the response trace without the body, which we capture separately
-	responseTrace, err := httputil.DumpResponse(response, false)
-	if err != nil {
-		return response, err
-	}
-	trace.ResponseTrace = responseTrace
+	// dump the response trace without the body, which we capture separately; ignore any dump error as we still
+	// have a usable response to hand back to the caller
+	trace.ResponseTrace, _ = httputil.DumpResponse(response, false)
 
 	// read the full body so we can both capture it and hand a readable copy back to the caller
-	body, err := io.ReadAll(response.Body)
+	body, readErr := io.ReadAll(response.Body)
 	response.Body.Close()
-	if err != nil {
-		return response, err
-	}
-	response.Body = io.NopCloser(bytes.NewReader(body))
 
-	// capture up to maxBodyBytes of the body into the trace
+	// capture up to maxBodyBytes of the body into the trace, cloning when truncating so we don't pin the full
+	// body's backing array
 	if t.maxBodyBytes > 0 && len(body) > t.maxBodyBytes {
-		trace.ResponseBody = body[:t.maxBodyBytes]
+		trace.ResponseBody = bytes.Clone(body[:t.maxBodyBytes])
 	} else {
 		trace.ResponseBody = body
+	}
+
+	// restore a readable body for the caller; if reading it failed, replay the partial bytes and the error so the
+	// caller sees exactly what it would have without tracing
+	if readErr != nil {
+		response.Body = io.NopCloser(io.MultiReader(bytes.NewReader(body), errReader{readErr}))
+	} else {
+		response.Body = io.NopCloser(bytes.NewReader(body))
 	}
 
 	return response, nil
 }
 
-// Traces returns the traces captured so far
+// Traces returns a snapshot of the traces captured so far
 func (t *TracingTransport) Traces() []*Trace {
-	return t.traces
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	return slices.Clone(t.traces)
 }
 
 var _ http.RoundTripper = (*TracingTransport)(nil)
+
+// errReader is an io.Reader that always returns its error, used to replay a body read failure to the caller
+type errReader struct{ err error }
+
+func (r errReader) Read([]byte) (int, error) { return 0, r.err }
 
 // NewRequest is a convenience method to create a request with the given context and headers
 func NewRequest(ctx context.Context, method string, url string, body io.Reader, headers map[string]string) (*http.Request, error) {

--- a/httpx/http_test.go
+++ b/httpx/http_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -176,6 +177,26 @@ func TestTracingTransport(t *testing.T) {
 	assert.Equal(t, `{ "ok": "true" }`, string(body))               // full body still readable
 	assert.Equal(t, `{ "o`, string(tt.Traces()[0].ResponseBody))    // captured body truncated to 4 bytes
 
+	// maxBodyBytes of 0 captures the entire body
+	tt = httpx.WithTracing(http.DefaultTransport, 0)
+	request, err = httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
+	require.NoError(t, err)
+	resp, err = tt.RoundTrip(request)
+	require.NoError(t, err)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, `{ "ok": "true" }`, string(body))
+	assert.Equal(t, `{ "ok": "true" }`, string(tt.Traces()[0].ResponseBody))
+
+	// the inner transport still sees the request body after DumpRequestOut has consumed and restored it
+	capturer := &bodyCapturingTransport{}
+	tt = httpx.WithTracing(capturer, -1)
+	request, err = httpx.NewRequest(ctx, "POST", "https://temba.io", bytes.NewReader([]byte("hello body")), nil)
+	require.NoError(t, err)
+	resp, err = tt.RoundTrip(request)
+	require.NoError(t, err)
+	assert.Equal(t, "hello body", string(capturer.body))
+
 	// an error from the inner transport is captured in the trace and returned
 	inner := httpx.WithMocking(http.DefaultTransport, map[string][]*httpx.MockResponse{
 		"https://temba.io": {httpx.MockConnectionError},
@@ -199,6 +220,39 @@ func TestTracingTransport(t *testing.T) {
 	resp, err = tt.RoundTrip(request)
 	require.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
+}
+
+// bodyCapturingTransport is a test http.RoundTripper that records the request body it received
+type bodyCapturingTransport struct{ body []byte }
+
+func (c *bodyCapturingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	c.body, _ = io.ReadAll(r.Body)
+	r.Body.Close()
+	return &http.Response{StatusCode: 200, Header: make(http.Header), Body: io.NopCloser(bytes.NewReader([]byte("ok")))}, nil
+}
+
+func TestTracingTransportConcurrent(t *testing.T) {
+	server := newTestHTTPServer(52027)
+	defer server.Close()
+
+	tt := httpx.WithTracing(http.DefaultTransport, -1)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			request, _ := http.NewRequest("GET", server.URL+"?cmd=success", nil)
+			resp, err := tt.RoundTrip(request)
+			if assert.NoError(t, err) {
+				io.ReadAll(resp.Body)
+				resp.Body.Close()
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Len(t, tt.Traces(), 20)
 }
 
 func TestMaxBodyBytes(t *testing.T) {

--- a/httpx/http_test.go
+++ b/httpx/http_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -123,6 +124,81 @@ func TestDoTrace(t *testing.T) {
 	assert.Equal(t, "HTTP/1.1 200 OK\r\nContent-Length: 6\r\nBad-Header: \x80\x81\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n", string(trace.ResponseTrace))
 	assert.Equal(t, 6, len(trace.ResponseBody))
 	assert.Equal(t, "HTTP/1.1 200 OK\r\nContent-Length: 6\r\nBad-Header: �\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n...", string(trace.SanitizedResponse("...")))
+}
+
+func TestTracingTransport(t *testing.T) {
+	ctx := context.Background()
+
+	defer dates.SetNowFunc(time.Now)
+	dates.SetNowFunc(dates.NewSequentialNow(time.Date(2019, 10, 7, 15, 21, 30, 123456789, time.UTC), time.Second))
+
+	server := newTestHTTPServer(52026)
+	defer server.Close()
+
+	tt := httpx.WithTracing(http.DefaultTransport, -1)
+
+	request, err := httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
+	require.NoError(t, err)
+	resp, err := tt.RoundTrip(request)
+	require.NoError(t, err)
+
+	// the caller can still read the full response body
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, `{ "ok": "true" }`, string(body))
+
+	// and a complete trace was captured
+	require.Len(t, tt.Traces(), 1)
+	trace := tt.Traces()[0]
+	assert.Equal(t, "GET /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:52026\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip\r\n\r\n", string(trace.RequestTrace))
+	assert.Equal(t, "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n", string(trace.ResponseTrace))
+	assert.Equal(t, `{ "ok": "true" }`, string(trace.ResponseBody))
+	assert.Equal(t, time.Date(2019, 10, 7, 15, 21, 30, 123456789, time.UTC), trace.StartTime)
+	assert.Equal(t, time.Date(2019, 10, 7, 15, 21, 31, 123456789, time.UTC), trace.EndTime)
+	assert.Equal(t, 0, trace.Retries)
+
+	// a second request accumulates another trace
+	request, err = httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
+	require.NoError(t, err)
+	resp, err = tt.RoundTrip(request)
+	require.NoError(t, err)
+	io.ReadAll(resp.Body)
+	assert.Len(t, tt.Traces(), 2)
+
+	// maxBodyBytes truncates the captured body, but the caller still reads the full body
+	tt = httpx.WithTracing(http.DefaultTransport, 4)
+	request, err = httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
+	require.NoError(t, err)
+	resp, err = tt.RoundTrip(request)
+	require.NoError(t, err)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, `{ "ok": "true" }`, string(body))               // full body still readable
+	assert.Equal(t, `{ "o`, string(tt.Traces()[0].ResponseBody))    // captured body truncated to 4 bytes
+
+	// an error from the inner transport is captured in the trace and returned
+	inner := httpx.WithMocking(http.DefaultTransport, map[string][]*httpx.MockResponse{
+		"https://temba.io": {httpx.MockConnectionError},
+	})
+	tt = httpx.WithTracing(inner, -1)
+	request, err = httpx.NewRequest(ctx, "GET", "https://temba.io", nil, nil)
+	require.NoError(t, err)
+	resp, err = tt.RoundTrip(request)
+	assert.EqualError(t, err, "unable to connect to server")
+	assert.Nil(t, resp)
+	require.Len(t, tt.Traces(), 1)
+	assert.NotNil(t, tt.Traces()[0].RequestTrace)
+	assert.Nil(t, tt.Traces()[0].Response)
+	assert.Nil(t, tt.Traces()[0].ResponseBody)
+
+	// a nil inner transport falls back to http.DefaultTransport
+	tt = httpx.WithTracing(nil, -1)
+	assert.NotNil(t, tt)
+	request, err = httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
+	require.NoError(t, err)
+	resp, err = tt.RoundTrip(request)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
 }
 
 func TestMaxBodyBytes(t *testing.T) {


### PR DESCRIPTION
## What

Adds `httpx.WithTracing(inner http.RoundTripper, maxBodyBytes int) *TracingTransport` — a tracing `http.RoundTripper` that captures a `*Trace` of each request/response (the same `Trace` type `DoTrace` produces) and delegates to an inner transport. This is the third composable building block, after `WithAccess` and `WithMocking`.

- Returns a concrete `*TracingTransport` that accumulates traces, exposed via `Traces() []*Trace` — mirroring how `*MockTransport` exposes `Requests()`.
- If `inner` is nil, `http.DefaultTransport` is used.
- Times come from `dates.Now()` (mockable in tests, same as `DoTrace`).

### The body-buffering constraint

`DoTrace` is terminal — it reads the response body into `trace.ResponseBody` (consuming it) and returns the `*Trace`, not a usable response. A `RoundTripper` is the opposite: it must return a response whose `Body` is still readable, because the caller (an SDK client, `http.Client.Do`) will read it. So `WithTracing` buffers the body, captures a copy into the trace, and hands a fresh readable body (`io.NopCloser(bytes.NewReader(...))`) back to the caller.

Two deliberate consequences (documented, and a divergence from `DoTrace` which is left untouched):
- `maxBodyBytes` limits only the *captured* copy in the trace; the **full body always passes through** to the caller. A too-large body is **not** turned into `ErrResponseSize` (that would break the caller's read).
- `Trace.Retries` is always 0 — retries live in `do()`, a layer above a single round trip.

## Why — broader direction

This completes the trio of composable `http.RoundTripper`s (access / mock / trace), the goal being that **any** `*http.Client` — including SDK-owned clients handed a plain `*http.Client` that never goes through `httpx.Do`/`DoTrace` — can opt into these concerns by wrapping its transport:

```go
client.Transport = httpx.WithAccess(
    httpx.WithTracing(
        httpx.WithMocking(client.Transport, mocks),
        maxBodyBytes,
    ),
    access,
)
```

With all three building blocks in place, the remaining step is to make `Do`/`DoTrace`/`SetRequestor` thin shims that assemble this chain internally (and eventually retire `MockRequestor`).

## Scope / compatibility

- Purely additive and backwards compatible — no exported signatures change; `Do`/`DoTrace`/`do()`/`SetRequestor` are untouched.
- New unit tests cover: trace captured (request/response trace + body) while the caller still reads the full body; trace accumulation across requests; deterministic start/end times via `dates.Now()`; `maxBodyBytes` truncates the captured copy but not the passed-through body; an inner error is captured (request trace present, no response/body) and returned; nil-inner falls back to `http.DefaultTransport`.
- Full `httpx` test suite and `go vet ./...` pass.