### PR TITLE
httpx: make MockTransport safe for concurrent use

### DIFF
--- a/httpx/mock.go
+++ b/httpx/mock.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/http"
 	"slices"
+	"sync"
 
 	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/gocommon/stringsx"
@@ -121,8 +122,10 @@ func hasUnusedMocks(mocks map[string][]*MockResponse) bool {
 
 // MockTransport is an http.RoundTripper which answers requests from a set of mocked responses, delegating to an
 // inner transport for requests it doesn't handle. It's intended to be the composable replacement for MockRequestor.
+// It is safe for concurrent use by multiple goroutines, as the http.RoundTripper contract requires.
 type MockTransport struct {
 	inner       http.RoundTripper
+	mutex       sync.Mutex // guards mocks and requests
 	mocks       map[string][]*MockResponse
 	requests    []*http.Request
 	ignoreLocal bool
@@ -165,7 +168,15 @@ func (t *MockTransport) RoundTrip(request *http.Request) (*http.Response, error)
 		return t.inner.RoundTrip(request)
 	}
 
+	// take the next matching mock and record the request under lock, but don't hold it across any delegation to
+	// the inner transport which may block on I/O
+	t.mutex.Lock()
 	mocked := takeMock(t.mocks, request)
+	if mocked != nil {
+		t.requests = append(t.requests, request)
+	}
+	t.mutex.Unlock()
+
 	if mocked == nil {
 		// no matching mock - either pass through to the inner transport or panic to catch the unexpected request
 		if t.passthrough {
@@ -174,8 +185,6 @@ func (t *MockTransport) RoundTrip(request *http.Request) (*http.Response, error)
 		panic(fmt.Sprintf("missing mock for URL %s", request.URL.String()))
 	}
 
-	t.requests = append(t.requests, request)
-
 	if mocked.Status == 0 {
 		return nil, errors.New("unable to connect to server")
 	}
@@ -183,13 +192,17 @@ func (t *MockTransport) RoundTrip(request *http.Request) (*http.Response, error)
 	return mocked.Make(request), nil
 }
 
-// Requests returns the requests that were answered from mocks
+// Requests returns a snapshot of the requests that were answered from mocks
 func (t *MockTransport) Requests() []*http.Request {
-	return t.requests
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	return slices.Clone(t.requests)
 }
 
 // HasUnused returns true if there are unused mocks leftover
 func (t *MockTransport) HasUnused() bool {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
 	return hasUnusedMocks(t.mocks)
 }
 

--- a/httpx/mock_test.go
+++ b/httpx/mock_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/nyaruka/gocommon/httpx"
@@ -201,6 +202,37 @@ func TestMockTransport(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode)
 	assert.Len(t, inner.Requests(), 1)
 	assert.Empty(t, mt.Requests())
+}
+
+func TestMockTransportConcurrent(t *testing.T) {
+	// a MockTransport shared across a client used by multiple goroutines must be safe for concurrent use, as the
+	// http.RoundTripper contract requires - run under -race to detect any unsynchronized access to mocks/requests
+	const n = 50
+	mocks := make([]*httpx.MockResponse, n)
+	for i := range mocks {
+		mocks[i] = httpx.NewMockResponse(200, nil, []byte("hi"))
+	}
+	mt := httpx.WithMocking(http.DefaultTransport, map[string][]*httpx.MockResponse{
+		"https://temba.io": mocks,
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req, _ := http.NewRequest("GET", "https://temba.io", nil)
+			resp, err := mt.RoundTrip(req)
+			if assert.NoError(t, err) {
+				io.ReadAll(resp.Body)
+				resp.Body.Close()
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Len(t, mt.Requests(), n)
+	assert.False(t, mt.HasUnused())
 }
 
 func TestMockRequestorMarshaling(t *testing.T) {


### PR DESCRIPTION
## What

`MockTransport.RoundTrip` appended to `requests` and mutated the `mocks` map (via `takeMock`) while `Requests()` and `HasUnused()` read them — all without synchronization. This is the same concurrency gap that #206 fixed in `TracingTransport`.

## Why

`http.RoundTripper` is documented as "safe for concurrent use by multiple goroutines," so a `MockTransport` shared across an `*http.Client` used by multiple goroutines could race (detectable under `go test -race`). This is test-infra-scoped today, but worth fixing for contract correctness since `MockTransport` is positioned to replace `MockRequestor`.

## How

- Add a `sync.Mutex` to `MockTransport` guarding `mocks` and `requests`, mirroring `TracingTransport`.
- In `RoundTrip`, hold the lock only across `takeMock` and the `requests` append — never across delegation to the inner transport, which may block on I/O. The append is folded into the `mocked != nil` branch so both mutations happen atomically under one lock, preserving the original behavior (only matched requests are recorded).
- `Requests()` returns a `slices.Clone` snapshot under lock, mirroring `TracingTransport.Traces()`.
- `HasUnused()` reads the map under lock.
- Add `TestMockTransportConcurrent`, a 50-goroutine `-race` test modeled on `TestTracingTransportConcurrent`.

## Verification

- `go test ./httpx/... -race -run TestMock` → ok
- `go test ./httpx/...` → ok
- `go vet ./...` → clean

Note: the full-package `go test ./httpx/... -race` surfaces a pre-existing race in `TestSocketClientCloseWithoutMessage` (websocket.go), confirmed present on `main` and unrelated to this change.