### PR TITLE
httpx: add WithBodyLimit transport to bound response body reads

### DIFF
--- a/httpx/limit.go
+++ b/httpx/limit.go
@@ -46,8 +46,9 @@ func (t *bodyLimitTransport) RoundTrip(request *http.Request) (*http.Response, e
 var _ http.RoundTripper = (*bodyLimitTransport)(nil)
 
 // limitedBody wraps a response body so that reading more than left bytes from it fails with ErrResponseSize. It
-// permits reading one byte beyond the limit so a body of exactly the limit is allowed while a larger one is reliably
-// detected, mirroring the semantics of DoTrace's maxBodyBytes.
+// permits reading one byte beyond the limit so that a body of exactly the limit is allowed while a larger one is
+// reliably detected; the read that crosses the limit returns the within-limit bytes alongside ErrResponseSize and
+// drops only the probe byte, following the io.Reader convention of reporting consumed bytes together with the error.
 type limitedBody struct {
 	inner io.ReadCloser
 	left  int64
@@ -65,7 +66,9 @@ func (b *limitedBody) Read(p []byte) (int, error) {
 	n, err := b.inner.Read(p)
 	b.left -= int64(n)
 	if b.left < 0 {
-		return 0, ErrResponseSize
+		// we read exactly one byte past the limit (n == old left + 1), so return the within-limit bytes and surface
+		// the size error, dropping only that probe byte
+		return n - 1, ErrResponseSize
 	}
 	return n, err
 }

--- a/httpx/limit.go
+++ b/httpx/limit.go
@@ -1,0 +1,73 @@
+package httpx
+
+import (
+	"io"
+	"net/http"
+)
+
+// bodyLimitTransport is an http.RoundTripper which bounds how many bytes can be read from each response body,
+// delegating to an inner transport. Reading a body beyond the limit fails with ErrResponseSize.
+type bodyLimitTransport struct {
+	inner    http.RoundTripper
+	maxBytes int
+}
+
+// WithBodyLimit wraps an http.RoundTripper so that reading more than maxBytes from any response body fails with
+// ErrResponseSize; a body of exactly maxBytes is allowed. A value <= 0 disables the limit. If inner is nil then
+// http.DefaultTransport is used.
+//
+// Unlike WithTracing's own limit — which only bounds how much of the body is captured into the trace — this bounds
+// the bytes actually read from the network, so it's what guards against buffering an arbitrarily large response from
+// an untrusted endpoint. To get that protection while also tracing, wrap this *inside* WithTracing so the limit
+// applies before the body is buffered:
+//
+//	httpx.WithTracing(httpx.WithBodyLimit(inner, maxBytes), captureBytes)
+//
+// Wrapping the other way around (WithBodyLimit outside WithTracing) is ineffective, as WithTracing reads the full
+// body into memory before the limit would be applied.
+func WithBodyLimit(inner http.RoundTripper, maxBytes int) http.RoundTripper {
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	return &bodyLimitTransport{inner: inner, maxBytes: maxBytes}
+}
+
+func (t *bodyLimitTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	response, err := t.inner.RoundTrip(request)
+	if err != nil || t.maxBytes <= 0 || response == nil || response.Body == nil {
+		return response, err
+	}
+
+	// wrap the body so reads beyond the limit surface ErrResponseSize to whoever consumes it
+	response.Body = &limitedBody{inner: response.Body, left: int64(t.maxBytes)}
+	return response, nil
+}
+
+var _ http.RoundTripper = (*bodyLimitTransport)(nil)
+
+// limitedBody wraps a response body so that reading more than left bytes from it fails with ErrResponseSize. It
+// permits reading one byte beyond the limit so a body of exactly the limit is allowed while a larger one is reliably
+// detected, mirroring the semantics of DoTrace's maxBodyBytes.
+type limitedBody struct {
+	inner io.ReadCloser
+	left  int64
+}
+
+func (b *limitedBody) Read(p []byte) (int, error) {
+	if b.left < 0 {
+		return 0, ErrResponseSize
+	}
+	// read at most one byte beyond the remaining allowance so we can distinguish an exactly-at-limit body from one
+	// that exceeds it
+	if int64(len(p)) > b.left+1 {
+		p = p[:b.left+1]
+	}
+	n, err := b.inner.Read(p)
+	b.left -= int64(n)
+	if b.left < 0 {
+		return 0, ErrResponseSize
+	}
+	return n, err
+}
+
+func (b *limitedBody) Close() error { return b.inner.Close() }

--- a/httpx/limit_test.go
+++ b/httpx/limit_test.go
@@ -43,6 +43,8 @@ func TestBodyLimitTransport(t *testing.T) {
 
 		if tc.expectErr {
 			assert.ErrorIs(t, err, httpx.ErrResponseSize, "limit=%d", tc.limit)
+			// the within-limit bytes are still returned alongside the error
+			assert.Equal(t, `{ "ok": "true" }`[:tc.limit], string(body), "limit=%d", tc.limit)
 		} else {
 			assert.NoError(t, err, "limit=%d", tc.limit)
 			assert.Equal(t, `{ "ok": "true" }`, string(body), "limit=%d", tc.limit)
@@ -57,6 +59,7 @@ func TestBodyLimitTransport(t *testing.T) {
 	resp, err := tt.RoundTrip(request)
 	require.NoError(t, err)
 	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
 	require.NoError(t, err)
 	assert.Equal(t, `{ "ok": "true" }`, string(body))
 
@@ -68,5 +71,71 @@ func TestBodyLimitTransport(t *testing.T) {
 	resp, err = tracing.RoundTrip(request)
 	require.NoError(t, err)
 	_, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
 	assert.ErrorIs(t, err, httpx.ErrResponseSize)
+
+	// an error from the inner transport is passed through unchanged, with no response to wrap
+	inner := httpx.WithMocking(http.DefaultTransport, map[string][]*httpx.MockResponse{
+		"https://temba.io": {httpx.MockConnectionError},
+	})
+	tt = httpx.WithBodyLimit(inner, 10)
+	request, err = httpx.NewRequest(ctx, "GET", "https://temba.io", nil, nil)
+	require.NoError(t, err)
+	resp, err = tt.RoundTrip(request)
+	assert.EqualError(t, err, "unable to connect to server")
+	assert.Nil(t, resp)
+
+	// closing the wrapped body closes the inner body
+	spy := &scriptedBody{data: []byte("hello")}
+	tt = httpx.WithBodyLimit(&fixedBodyTransport{body: spy}, 100)
+	request, err = httpx.NewRequest(ctx, "GET", "https://temba.io", nil, nil)
+	require.NoError(t, err)
+	resp, err = tt.RoundTrip(request)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	assert.True(t, spy.closed)
+
+	// a body delivered in small chunks that straddles the limit yields exactly the within-limit bytes plus the size
+	// error, exercising the multi-call accounting in limitedBody.Read
+	chunked := &scriptedBody{data: []byte("0123456789abcdefghij"), chunk: 3}
+	tt = httpx.WithBodyLimit(&fixedBodyTransport{body: chunked}, 8)
+	request, err = httpx.NewRequest(ctx, "GET", "https://temba.io", nil, nil)
+	require.NoError(t, err)
+	resp, err = tt.RoundTrip(request)
+	require.NoError(t, err)
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	assert.ErrorIs(t, err, httpx.ErrResponseSize)
+	assert.Equal(t, "01234567", string(body))
+}
+
+// scriptedBody is a test io.ReadCloser that yields its data in fixed-size chunks (chunk <= 0 means all at once) and
+// records whether it was closed.
+type scriptedBody struct {
+	data   []byte
+	pos    int
+	chunk  int
+	closed bool
+}
+
+func (b *scriptedBody) Read(p []byte) (int, error) {
+	if b.pos >= len(b.data) {
+		return 0, io.EOF
+	}
+	end := len(b.data)
+	if b.chunk > 0 && b.pos+b.chunk < end {
+		end = b.pos + b.chunk
+	}
+	n := copy(p, b.data[b.pos:end])
+	b.pos += n
+	return n, nil
+}
+
+func (b *scriptedBody) Close() error { b.closed = true; return nil }
+
+// fixedBodyTransport is a test http.RoundTripper that returns a 200 response with a preset body.
+type fixedBodyTransport struct{ body io.ReadCloser }
+
+func (t *fixedBodyTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: 200, Header: make(http.Header), Body: t.body}, nil
 }

--- a/httpx/limit_test.go
+++ b/httpx/limit_test.go
@@ -1,0 +1,72 @@
+package httpx_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/nyaruka/gocommon/httpx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBodyLimitTransport(t *testing.T) {
+	ctx := context.Background()
+
+	server := newTestHTTPServer(52028)
+	defer server.Close()
+
+	// ?cmd=success returns a 16-byte body
+	tcs := []struct {
+		limit     int
+		expectErr bool
+	}{
+		{limit: -1, expectErr: false}, // negative limit means no limit
+		{limit: 0, expectErr: false},  // zero limit means no limit
+		{limit: 15, expectErr: true},  // one byte short of the body size
+		{limit: 16, expectErr: false}, // exactly the body size is allowed
+		{limit: 20, expectErr: false}, // comfortably larger than the body
+	}
+
+	for _, tc := range tcs {
+		tt := httpx.WithBodyLimit(http.DefaultTransport, tc.limit)
+		request, err := httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
+		require.NoError(t, err)
+
+		// the limit only surfaces when the body is read, not from RoundTrip itself
+		resp, err := tt.RoundTrip(request)
+		require.NoError(t, err, "limit=%d", tc.limit)
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		if tc.expectErr {
+			assert.ErrorIs(t, err, httpx.ErrResponseSize, "limit=%d", tc.limit)
+		} else {
+			assert.NoError(t, err, "limit=%d", tc.limit)
+			assert.Equal(t, `{ "ok": "true" }`, string(body), "limit=%d", tc.limit)
+		}
+	}
+
+	// a nil inner transport falls back to http.DefaultTransport
+	tt := httpx.WithBodyLimit(nil, 1024)
+	require.NotNil(t, tt)
+	request, err := httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
+	require.NoError(t, err)
+	resp, err := tt.RoundTrip(request)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, `{ "ok": "true" }`, string(body))
+
+	// composed inside WithTracing, the limit bounds the body before it's buffered, so the caller reading the
+	// handed-back body sees ErrResponseSize rather than WithTracing silently buffering the whole thing
+	tracing := httpx.WithTracing(httpx.WithBodyLimit(http.DefaultTransport, 4), -1)
+	request, err = httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
+	require.NoError(t, err)
+	resp, err = tracing.RoundTrip(request)
+	require.NoError(t, err)
+	_, err = io.ReadAll(resp.Body)
+	assert.ErrorIs(t, err, httpx.ErrResponseSize)
+}


### PR DESCRIPTION
## What

Adds `httpx.WithBodyLimit(inner, maxBytes)` — an `http.RoundTripper` that bounds how many bytes can be read from each response body, returning `ErrResponseSize` once a body exceeds the limit. A body of exactly `maxBytes` is allowed; a value `<= 0` disables the limit; a nil inner transport falls back to `http.DefaultTransport`, matching the other `With*` wrappers.

## Why

`WithTracing`'s own `maxBodyBytes` only caps how much of the body is *captured into the trace* — it still calls `io.ReadAll` and buffers the **entire** body into memory. That's fine for trusted endpoints but offers no protection against an untrusted endpoint returning an arbitrarily large (or unbounded) response.

`WithBodyLimit` supplies the missing read/memory bound, and the two compose cleanly:

```go
httpx.WithTracing(httpx.WithBodyLimit(inner, maxBytes), captureBytes)
```

- `WithBodyLimit` — hard ceiling on bytes read from the network (rejects oversized bodies with `ErrResponseSize`)
- `WithTracing` — buffers the now-bounded body, hands it back readable, and stores `captureBytes` in the trace

This reproduces the behaviour of `DoTrace` with a positive `maxBodyBytes` (bound reads from an untrusted endpoint, keep a small trace) using composable transports, so callers can move off `DoTrace` onto a single tracing path.

## Reviewer notes

- **Ordering matters.** `WithBodyLimit` must be wrapped *inside* `WithTracing` so the limit applies before the body is buffered. Wrapping it on the outside is ineffective (the full body is already in memory). The doc comment calls this out.
- **Where the error surfaces.** The limit is enforced lazily on the response body, so `ErrResponseSize` surfaces when the body is *read*, not from `RoundTrip`/`client.Do` — consistent with how a `WithTracing` body read failure is replayed to the caller.
- Reuses the existing `ErrResponseSize`; no new exported error.
- `limitedBody` reads one byte past the allowance to distinguish exactly-at-limit from over-limit, mirroring `DoTrace`'s `readBody` semantics.
- New test `TestBodyLimitTransport` covers the limit matrix (no-limit / under / exact boundary / over), nil-inner fallback, and the `WithTracing(WithBodyLimit(...))` composition. All `httpx` tests pass, including under `-race`.