### PR TITLE
httpx: remove maxBodyBytes parameter from WithTracing

### DIFF
--- a/httpx/http.go
+++ b/httpx/http.go
@@ -162,20 +162,20 @@ func DoTrace(client *http.Client, request *http.Request, retries *RetryConfig, a
 // inner transport. The response body is buffered so that it remains readable by the caller. It is safe for
 // concurrent use by multiple goroutines, as the http.RoundTripper contract requires.
 type TracingTransport struct {
-	inner        http.RoundTripper
-	maxBodyBytes int
-	mutex        sync.Mutex
-	traces       []*Trace
+	inner  http.RoundTripper
+	mutex  sync.Mutex
+	traces []*Trace
 }
 
 // WithTracing wraps an http.RoundTripper so that each request and response is captured as a *Trace, retrievable via
-// Traces(). The response body is buffered so it remains readable by the caller; at most maxBodyBytes of it are
-// captured into the trace (a value <= 0 captures the entire body). If inner is nil then http.DefaultTransport is used.
-func WithTracing(inner http.RoundTripper, maxBodyBytes int) *TracingTransport {
+// Traces(). The response body is buffered so it remains readable by the caller, and the full body that was read is
+// captured into the trace. To bound how many bytes are read from an untrusted endpoint, wrap the inner transport with
+// WithBodyLimit, e.g. WithTracing(WithBodyLimit(inner, n)). If inner is nil then http.DefaultTransport is used.
+func WithTracing(inner http.RoundTripper) *TracingTransport {
 	if inner == nil {
 		inner = http.DefaultTransport
 	}
-	return &TracingTransport{inner: inner, maxBodyBytes: maxBodyBytes}
+	return &TracingTransport{inner: inner}
 }
 
 func (t *TracingTransport) RoundTrip(request *http.Request) (*http.Response, error) {
@@ -213,13 +213,8 @@ func (t *TracingTransport) RoundTrip(request *http.Request) (*http.Response, err
 	body, readErr := io.ReadAll(response.Body)
 	response.Body.Close()
 
-	// capture up to maxBodyBytes of the body into the trace, cloning when truncating so we don't pin the full
-	// body's backing array
-	if t.maxBodyBytes > 0 && len(body) > t.maxBodyBytes {
-		trace.ResponseBody = bytes.Clone(body[:t.maxBodyBytes])
-	} else {
-		trace.ResponseBody = body
-	}
+	// capture the full body that was read into the trace
+	trace.ResponseBody = body
 
 	// restore a readable body for the caller; if reading it failed, replay the partial bytes and the error so the
 	// caller sees exactly what it would have without tracing

--- a/httpx/http_test.go
+++ b/httpx/http_test.go
@@ -136,7 +136,7 @@ func TestTracingTransport(t *testing.T) {
 	server := newTestHTTPServer(52026)
 	defer server.Close()
 
-	tt := httpx.WithTracing(http.DefaultTransport, -1)
+	tt := httpx.WithTracing(http.DefaultTransport)
 
 	request, err := httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
 	require.NoError(t, err)
@@ -166,31 +166,9 @@ func TestTracingTransport(t *testing.T) {
 	io.ReadAll(resp.Body)
 	assert.Len(t, tt.Traces(), 2)
 
-	// maxBodyBytes truncates the captured body, but the caller still reads the full body
-	tt = httpx.WithTracing(http.DefaultTransport, 4)
-	request, err = httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
-	require.NoError(t, err)
-	resp, err = tt.RoundTrip(request)
-	require.NoError(t, err)
-	body, err = io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	assert.Equal(t, `{ "ok": "true" }`, string(body))               // full body still readable
-	assert.Equal(t, `{ "o`, string(tt.Traces()[0].ResponseBody))    // captured body truncated to 4 bytes
-
-	// maxBodyBytes of 0 captures the entire body
-	tt = httpx.WithTracing(http.DefaultTransport, 0)
-	request, err = httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
-	require.NoError(t, err)
-	resp, err = tt.RoundTrip(request)
-	require.NoError(t, err)
-	body, err = io.ReadAll(resp.Body)
-	require.NoError(t, err)
-	assert.Equal(t, `{ "ok": "true" }`, string(body))
-	assert.Equal(t, `{ "ok": "true" }`, string(tt.Traces()[0].ResponseBody))
-
 	// the inner transport still sees the request body after DumpRequestOut has consumed and restored it
 	capturer := &bodyCapturingTransport{}
-	tt = httpx.WithTracing(capturer, -1)
+	tt = httpx.WithTracing(capturer)
 	request, err = httpx.NewRequest(ctx, "POST", "https://temba.io", bytes.NewReader([]byte("hello body")), nil)
 	require.NoError(t, err)
 	resp, err = tt.RoundTrip(request)
@@ -201,7 +179,7 @@ func TestTracingTransport(t *testing.T) {
 	inner := httpx.WithMocking(http.DefaultTransport, map[string][]*httpx.MockResponse{
 		"https://temba.io": {httpx.MockConnectionError},
 	})
-	tt = httpx.WithTracing(inner, -1)
+	tt = httpx.WithTracing(inner)
 	request, err = httpx.NewRequest(ctx, "GET", "https://temba.io", nil, nil)
 	require.NoError(t, err)
 	resp, err = tt.RoundTrip(request)
@@ -213,7 +191,7 @@ func TestTracingTransport(t *testing.T) {
 	assert.Nil(t, tt.Traces()[0].ResponseBody)
 
 	// a nil inner transport falls back to http.DefaultTransport
-	tt = httpx.WithTracing(nil, -1)
+	tt = httpx.WithTracing(nil)
 	assert.NotNil(t, tt)
 	request, err = httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
 	require.NoError(t, err)
@@ -235,7 +213,7 @@ func TestTracingTransportConcurrent(t *testing.T) {
 	server := newTestHTTPServer(52027)
 	defer server.Close()
 
-	tt := httpx.WithTracing(http.DefaultTransport, -1)
+	tt := httpx.WithTracing(http.DefaultTransport)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 20; i++ {

--- a/httpx/limit.go
+++ b/httpx/limit.go
@@ -16,12 +16,11 @@ type bodyLimitTransport struct {
 // ErrResponseSize; a body of exactly maxBytes is allowed. A value <= 0 disables the limit. If inner is nil then
 // http.DefaultTransport is used.
 //
-// Unlike WithTracing's own limit — which only bounds how much of the body is captured into the trace — this bounds
-// the bytes actually read from the network, so it's what guards against buffering an arbitrarily large response from
-// an untrusted endpoint. To get that protection while also tracing, wrap this *inside* WithTracing so the limit
-// applies before the body is buffered:
+// This bounds the bytes actually read from the network, so it's what guards against buffering an arbitrarily large
+// response from an untrusted endpoint. To get that protection while also tracing, wrap this *inside* WithTracing so
+// the limit applies before the body is buffered:
 //
-//	httpx.WithTracing(httpx.WithBodyLimit(inner, maxBytes), captureBytes)
+//	httpx.WithTracing(httpx.WithBodyLimit(inner, maxBytes))
 //
 // Wrapping the other way around (WithBodyLimit outside WithTracing) is ineffective, as WithTracing reads the full
 // body into memory before the limit would be applied.

--- a/httpx/limit_test.go
+++ b/httpx/limit_test.go
@@ -65,7 +65,7 @@ func TestBodyLimitTransport(t *testing.T) {
 
 	// composed inside WithTracing, the limit bounds the body before it's buffered, so the caller reading the
 	// handed-back body sees ErrResponseSize rather than WithTracing silently buffering the whole thing
-	tracing := httpx.WithTracing(httpx.WithBodyLimit(http.DefaultTransport, 4), -1)
+	tracing := httpx.WithTracing(httpx.WithBodyLimit(http.DefaultTransport, 4))
 	request, err = httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
 	require.NoError(t, err)
 	resp, err = tracing.RoundTrip(request)


### PR DESCRIPTION
## Summary

`WithTracing` did two jobs: capture a `*Trace` of each request/response, and use its `maxBodyBytes` argument to cap how many response bytes were kept *in the trace*. That knob never bounded the bytes read from the network — `RoundTrip` always read the entire body and only truncated the captured copy — so it was easy to mistake for a read limit.

Bounding the read is now the separate job of `WithBodyLimit` (added in v1.81.2), which composes *inside* `WithTracing`. This change removes the overlapping capture knob so `WithTracing` does one thing: trace, capturing the full body it reads.

## Changes

- `WithTracing(inner http.RoundTripper) *TracingTransport` — dropped the `maxBodyBytes` parameter and the corresponding struct field.
- `RoundTrip` always captures the full body that was read into the trace; the rest (request dump, body-read-error replay, timing, concurrency safety) is unchanged.
- Updated doc comments on `WithTracing` and `WithBodyLimit`. Callers that need to bound bytes read from an untrusted endpoint compose `WithTracing(WithBodyLimit(inner, n))`.
- Updated in-repo callers/tests; removed the now-obsolete capture-truncation assertions (full-body capture is still covered).

## Notes

- **Breaking API change** — downstream consumers that pass a second argument will need to drop it (and compose `WithBodyLimit` if they relied on the capture cap).
- `go build ./...` and `go vet ./...` pass; full test suite passes (`go test -p=1 ./...`), and the httpx package is race-clean under `-race` (the unrelated, pre-existing websocket-test race is not touched by this change).