### PR TITLE
httpx: add composable WithRetries transport

### DIFF
--- a/httpx/retries.go
+++ b/httpx/retries.go
@@ -100,6 +100,11 @@ func ParseRetryAfter(value string) time.Duration {
 	return 0
 }
 
+// maxRetryDrain caps how many bytes of a to-be-discarded response body we drain before retrying. Draining lets the
+// underlying connection be reused, but an unbounded drain of a large or slow error body could cost more than the
+// reuse it buys, so we bound it to the same size net/http.Transport uses for the same purpose.
+const maxRetryDrain = 2 << 10 // 2KB
+
 // retryTransport is an http.RoundTripper which retries requests according to a RetryConfig, delegating each attempt
 // to an inner transport. It holds no mutable state, so it's safe for concurrent use by multiple goroutines, as the
 // http.RoundTripper contract requires.
@@ -158,9 +163,10 @@ func (t *retryTransport) RoundTrip(request *http.Request) (*http.Response, error
 			return response, err
 		}
 
-		// drain and close the response we're discarding so the underlying connection can be reused
+		// drain and close the response we're discarding so the underlying connection can be reused; cap the drain
+		// (as net/http.Transport does) so a large or slow error body doesn't cost more than the reuse it buys
 		if response != nil {
-			io.Copy(io.Discard, response.Body)
+			io.CopyN(io.Discard, response.Body, maxRetryDrain)
 			response.Body.Close()
 		}
 
@@ -191,6 +197,12 @@ var _ http.RoundTripper = (*retryTransport)(nil)
 
 // wait blocks for the given duration, returning early with the context's error if it is cancelled first.
 func wait(ctx context.Context, d time.Duration) error {
+	// check for cancellation up front so a zero or already-elapsed backoff can't race the select into returning nil
+	// when the context is already done
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	timer := time.NewTimer(d)
 	defer timer.Stop()
 

--- a/httpx/retries.go
+++ b/httpx/retries.go
@@ -1,9 +1,12 @@
 package httpx
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/nyaruka/gocommon/dates"
@@ -95,4 +98,124 @@ func ParseRetryAfter(value string) time.Duration {
 	}
 
 	return 0
+}
+
+// retryTransport is an http.RoundTripper which retries requests according to a RetryConfig, delegating each attempt
+// to an inner transport. It holds no mutable state, so it's safe for concurrent use by multiple goroutines, as the
+// http.RoundTripper contract requires.
+type retryTransport struct {
+	inner   http.RoundTripper
+	retries *RetryConfig
+}
+
+// WithRetries wraps an http.RoundTripper so that requests are retried with backoff according to the given RetryConfig.
+// After each attempt, while retries remain, it asks retries.ShouldRetry whether the request/response warrants another
+// try and, if so, waits the configured backoff before retrying. A nil config makes it a pass-through, so it's always
+// safe to wrap. If inner is nil then http.DefaultTransport is used.
+//
+// A request with a body is only retried if the body can be rewound, i.e. it has a non-nil GetBody (which
+// http.NewRequest populates automatically for the common in-memory body types). This mirrors how net/http.Transport
+// itself decides whether a request is replayable (see https://github.com/golang/go/issues/18241). Between attempts
+// the discarded response body is drained and closed so the underlying connection can be reused, and the backoff wait
+// is aborted early if the request's context is cancelled.
+//
+// To recover how many retries happened, compose this inside WithTraces:
+//
+//	httpx.WithTraces(httpx.WithRetries(inner, retries))
+//
+// In that arrangement the outer tracer captures a single Trace of the final attempt, with Trace.Retries set to the
+// number of retries performed. (Composed the other way around, httpx.WithRetries(httpx.WithTraces(inner), retries),
+// each attempt is captured as its own trace and the count is len(traces)-1.)
+func WithRetries(inner http.RoundTripper, retries *RetryConfig) http.RoundTripper {
+	if inner == nil {
+		inner = http.DefaultTransport
+	}
+	return &retryTransport{inner: inner, retries: retries}
+}
+
+func (t *retryTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	// an outer TracesTransport may have installed a counter for us to report retries through
+	count := retryCountFromContext(request.Context())
+
+	retry := 0
+	for {
+		response, err := t.inner.RoundTrip(request)
+
+		// stop if there's no retry config or we've used up our allowance
+		if t.retries == nil || retry >= t.retries.MaxRetries() {
+			return response, err
+		}
+
+		backoff := t.retries.Backoff(retry)
+		if !t.retries.ShouldRetry(request, response, backoff) {
+			return response, err
+		}
+
+		// we can only make another attempt if there's no body to resend or we can rewind it via GetBody; an empty
+		// http.NoBody needs no rewinding. This mirrors net/http.Transport's own conservative behaviour for replaying
+		// requests (see https://github.com/golang/go/issues/18241).
+		if request.Body != nil && request.Body != http.NoBody && request.GetBody == nil {
+			return response, err
+		}
+
+		// drain and close the response we're discarding so the underlying connection can be reused
+		if response != nil {
+			io.Copy(io.Discard, response.Body)
+			response.Body.Close()
+		}
+
+		// wait out the backoff, but abort early if the request's context is cancelled
+		if werr := wait(request.Context(), backoff); werr != nil {
+			return nil, werr
+		}
+
+		// rewind the body for the next attempt by cloning the request with a fresh body from GetBody; cloning
+		// rather than mutating leaves the caller's request untouched
+		if request.Body != nil && request.Body != http.NoBody {
+			body, gerr := request.GetBody()
+			if gerr != nil {
+				return nil, gerr
+			}
+			request = request.Clone(request.Context())
+			request.Body = body
+		}
+
+		retry++
+		if count != nil {
+			count.Add(1)
+		}
+	}
+}
+
+var _ http.RoundTripper = (*retryTransport)(nil)
+
+// wait blocks for the given duration, returning early with the context's error if it is cancelled first.
+func wait(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// retryCountKey is the unexported context key under which a retry counter is carried so that an outer TracesTransport
+// can recover how many retries an inner retryTransport performed. See WithRetries.
+type retryCountKey struct{}
+
+// contextWithRetryCount returns a copy of ctx carrying a fresh retry counter, along with that counter. An outer
+// transport (e.g. the one built by WithTraces) installs this before delegating so that an inner retryTransport can
+// record how many retries it made and the outer transport can read the count back when finalizing its trace.
+func contextWithRetryCount(ctx context.Context) (context.Context, *atomic.Int64) {
+	count := &atomic.Int64{}
+	return context.WithValue(ctx, retryCountKey{}, count), count
+}
+
+// retryCountFromContext returns the retry counter carried in ctx, or nil if none was installed.
+func retryCountFromContext(ctx context.Context) *atomic.Int64 {
+	count, _ := ctx.Value(retryCountKey{}).(*atomic.Int64)
+	return count
 }

--- a/httpx/retries_test.go
+++ b/httpx/retries_test.go
@@ -2,7 +2,11 @@ package httpx_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -152,4 +156,260 @@ func TestParseRetryAfter(t *testing.T) {
 	assert.Equal(t, 10*time.Second, httpx.ParseRetryAfter("10"))
 	assert.Equal(t, 4500*time.Millisecond, httpx.ParseRetryAfter("Wed, 07 Jan 2020 15:10:35 GMT")) // 4.5 seconds in future
 	assert.Equal(t, 0*time.Second, httpx.ParseRetryAfter("Wed, 07 Jan 2020 15:10:25 GMT"))         // 5.5 seconds in the past
+}
+
+// recordingTransport is a test http.RoundTripper which returns a programmed sequence of responses (a zero status
+// simulating a connection error) and records the request body bytes each attempt received.
+type recordingTransport struct {
+	steps  []recordedStep
+	bodies [][]byte
+	calls  int
+}
+
+type recordedStep struct {
+	status  int
+	headers map[string]string
+	body    string
+}
+
+func (rt *recordingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	var body []byte
+	if r.Body != nil {
+		body, _ = io.ReadAll(r.Body)
+		r.Body.Close()
+	}
+	rt.bodies = append(rt.bodies, body)
+
+	step := rt.steps[rt.calls]
+	rt.calls++
+
+	if step.status == 0 {
+		return nil, errors.New("unable to connect to server")
+	}
+
+	header := make(http.Header)
+	for k, v := range step.headers {
+		header.Set(k, v)
+	}
+	return &http.Response{
+		StatusCode:    step.status,
+		Status:        fmt.Sprintf("%d %s", step.status, http.StatusText(step.status)),
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        header,
+		Body:          io.NopCloser(strings.NewReader(step.body)),
+		ContentLength: int64(len(step.body)),
+		Request:       r,
+	}, nil
+}
+
+func TestWithRetries(t *testing.T) {
+	ctx := context.Background()
+
+	// tiny backoffs to keep the test fast; two retries allowed
+	retries := httpx.NewFixedRetries(time.Millisecond, time.Millisecond)
+
+	// a retryable status that eventually succeeds
+	inner := &recordingTransport{steps: []recordedStep{
+		{status: 503, body: "fail"},
+		{status: 503, body: "fail"},
+		{status: 200, body: "ok"},
+	}}
+	req, err := httpx.NewRequest(ctx, "GET", "http://temba.io/", nil, nil)
+	require.NoError(t, err)
+	resp, err := httpx.WithRetries(inner, retries).RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, 3, inner.calls)
+
+	// the final response body is still readable and un-drained
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", string(body))
+
+	// retries exhausted returns the last response (still readable)
+	inner = &recordingTransport{steps: []recordedStep{
+		{status: 503, body: "a"},
+		{status: 503, body: "b"},
+		{status: 503, body: "c"},
+	}}
+	req, _ = httpx.NewRequest(ctx, "GET", "http://temba.io/", nil, nil)
+	resp, err = httpx.WithRetries(inner, retries).RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, 503, resp.StatusCode)
+	assert.Equal(t, 3, inner.calls)
+	body, _ = io.ReadAll(resp.Body)
+	assert.Equal(t, "c", string(body))
+
+	// no retry when the first response doesn't warrant it
+	inner = &recordingTransport{steps: []recordedStep{{status: 200, body: "ok"}}}
+	req, _ = httpx.NewRequest(ctx, "GET", "http://temba.io/", nil, nil)
+	resp, err = httpx.WithRetries(inner, retries).RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, 1, inner.calls)
+
+	// no retry for a non-idempotent request (POST without an idempotency key)
+	inner = &recordingTransport{steps: []recordedStep{{status: 503, body: "fail"}}}
+	req, _ = httpx.NewRequest(ctx, "POST", "http://temba.io/", strings.NewReader("data"), nil)
+	resp, err = httpx.WithRetries(inner, retries).RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, 503, resp.StatusCode)
+	assert.Equal(t, 1, inner.calls)
+
+	// retry on a connection error for an idempotent request
+	inner = &recordingTransport{steps: []recordedStep{
+		{status: 0}, // connection error
+		{status: 200, body: "ok"},
+	}}
+	req, _ = httpx.NewRequest(ctx, "GET", "http://temba.io/", nil, nil)
+	resp, err = httpx.WithRetries(inner, retries).RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, 2, inner.calls)
+
+	// a nil config makes it a pass-through with no retries
+	inner = &recordingTransport{steps: []recordedStep{{status: 503, body: "fail"}}}
+	req, _ = httpx.NewRequest(ctx, "GET", "http://temba.io/", nil, nil)
+	resp, err = httpx.WithRetries(inner, nil).RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, 503, resp.StatusCode)
+	assert.Equal(t, 1, inner.calls)
+}
+
+func TestWithRetriesBodyReplay(t *testing.T) {
+	ctx := context.Background()
+	retries := httpx.NewFixedRetries(time.Millisecond, time.Millisecond)
+
+	inner := &recordingTransport{steps: []recordedStep{
+		{status: 503, body: "fail"},
+		{status: 200, body: "ok"},
+	}}
+	// a POST is idempotent here via the header, and strings.NewReader gives the request a GetBody so it can be replayed
+	req, err := httpx.NewRequest(ctx, "POST", "http://temba.io/", strings.NewReader("payload"), map[string]string{"Idempotency-Key": "abc"})
+	require.NoError(t, err)
+	resp, err := httpx.WithRetries(inner, retries).RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	require.Equal(t, 2, inner.calls)
+
+	// the full body was replayed on every attempt
+	assert.Equal(t, "payload", string(inner.bodies[0]))
+	assert.Equal(t, "payload", string(inner.bodies[1]))
+}
+
+func TestWithRetriesUnrewindableBody(t *testing.T) {
+	ctx := context.Background()
+	retries := httpx.NewFixedRetries(time.Millisecond, time.Millisecond)
+
+	inner := &recordingTransport{steps: []recordedStep{
+		{status: 503, body: "fail"},
+		{status: 200, body: "ok"},
+	}}
+	// a body that isn't one of the rewindable types, so http.NewRequest leaves GetBody nil
+	req, err := http.NewRequestWithContext(ctx, "POST", "http://temba.io/", io.NopCloser(strings.NewReader("payload")))
+	require.NoError(t, err)
+	req.Header.Set("Idempotency-Key", "abc") // ShouldRetry would allow a retry...
+	require.Nil(t, req.GetBody)              // ...but the body can't be rewound
+
+	resp, err := httpx.WithRetries(inner, retries).RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, 503, resp.StatusCode) // so we don't retry, and return the first response
+	assert.Equal(t, 1, inner.calls)
+}
+
+func TestWithRetriesRetryAfter(t *testing.T) {
+	ctx := context.Background()
+
+	defer dates.SetNowFunc(time.Now)
+	now := time.Date(2020, 1, 7, 15, 10, 30, 950000000, time.UTC)
+	dates.SetNowFunc(dates.NewFixedNow(now))
+
+	// a Retry-After 50ms in the future, with a backoff long enough to honour it
+	retryAfter := now.Add(50 * time.Millisecond).UTC().Format(http.TimeFormat)
+	retries := httpx.NewFixedRetries(50 * time.Millisecond)
+
+	inner := &recordingTransport{steps: []recordedStep{
+		{status: 429, headers: map[string]string{"Retry-After": retryAfter}, body: "slow down"},
+		{status: 200, body: "ok"},
+	}}
+	req, err := httpx.NewRequest(ctx, "GET", "http://temba.io/", nil, nil)
+	require.NoError(t, err)
+	resp, err := httpx.WithRetries(inner, retries).RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, 2, inner.calls)
+}
+
+func TestWithRetriesAndTraces(t *testing.T) {
+	ctx := context.Background()
+
+	defer dates.SetNowFunc(time.Now)
+	dates.SetNowFunc(dates.NewSequentialNow(time.Date(2019, 10, 7, 15, 21, 30, 0, time.UTC), time.Second))
+
+	retries := httpx.NewFixedRetries(time.Millisecond, time.Millisecond)
+
+	inner := &recordingTransport{steps: []recordedStep{
+		{status: 503, body: "fail"},
+		{status: 503, body: "fail"},
+		{status: 200, body: "ok"},
+	}}
+
+	// WithTraces(WithRetries(inner)) captures a single trace of the final attempt, with the retry count surfaced
+	tt := httpx.WithTraces(httpx.WithRetries(inner, retries))
+	req, err := httpx.NewRequest(ctx, "GET", "http://temba.io/", nil, nil)
+	require.NoError(t, err)
+	resp, err := tt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", string(body))
+
+	require.Len(t, tt.Traces(), 1)
+	trace := tt.Traces()[0]
+	assert.Equal(t, 200, trace.Response.StatusCode)
+	assert.Equal(t, "ok", string(trace.ResponseBody))
+	assert.Equal(t, 2, trace.Retries)
+}
+
+func TestWithRetriesContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// a long backoff we should never actually wait out because the context is already cancelled
+	retries := httpx.NewFixedRetries(time.Minute)
+
+	inner := &recordingTransport{steps: []recordedStep{
+		{status: 503, body: "fail"},
+		{status: 200, body: "ok"},
+	}}
+	req, err := httpx.NewRequest(ctx, "GET", "http://temba.io/", nil, nil)
+	require.NoError(t, err)
+
+	cancel() // cancel before the backoff wait
+
+	resp, err := httpx.WithRetries(inner, retries).RoundTrip(req)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, resp)
+	assert.Equal(t, 1, inner.calls) // only the first attempt happened
+}
+
+func TestWithRetriesNilInner(t *testing.T) {
+	ctx := context.Background()
+	server := newTestHTTPServer(52030)
+	defer server.Close()
+
+	// a nil inner transport falls back to http.DefaultTransport
+	tr := httpx.WithRetries(nil, httpx.NewFixedRetries(time.Millisecond))
+	req, err := httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
+	require.NoError(t, err)
+	resp, err := tr.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	assert.Equal(t, `{ "ok": "true" }`, string(body))
 }

--- a/httpx/traces.go
+++ b/httpx/traces.go
@@ -147,6 +147,11 @@ func (t *TracesTransport) RoundTrip(request *http.Request) (*http.Response, erro
 		return nil, err
 	}
 
+	// carry a counter so that an inner retryTransport, if composed inside us, can report how many retries it made,
+	// which we then surface as Trace.Retries
+	ctx, retryCount := contextWithRetryCount(request.Context())
+	request = request.WithContext(ctx)
+
 	trace := &Trace{
 		Request:      request,
 		RequestTrace: requestTrace,
@@ -159,6 +164,7 @@ func (t *TracesTransport) RoundTrip(request *http.Request) (*http.Response, erro
 
 	response, err := t.inner.RoundTrip(request)
 	trace.Response = response
+	trace.Retries = int(retryCount.Load())
 	if err != nil {
 		// the inner transport failed to obtain a response
 		return nil, err


### PR DESCRIPTION
## What

Adds `WithRetries(inner http.RoundTripper, retries *RetryConfig) http.RoundTripper` — the composable retry transport that was missing from the `httpx` `With*` family (`WithTraces`, `WithReadLimit`, `WithAccessControl`, `WithMocks`).

```go
client := &http.Client{Transport: httpx.WithTraces(httpx.WithRetries(nil, retries))}
```

## Why

The package is migrating from the bundled `Do`/`DoTrace`/`MockRequestor` helpers (now `Deprecated:`) to composable `http.RoundTripper` transports. `Do`/`DoTrace` bundled retry-with-backoff via `*RetryConfig`, but there was no composable equivalent, so downstream consumers that used `DoTrace(client, req, retries, ...)` had nothing to migrate their retry behaviour onto. This fills that gap; `RetryConfig` itself is unchanged.

## Behaviour

The retry loop replicates `do()`'s `ShouldRetry`/`Backoff`/`MaxRetries` semantics exactly, with several deliberate correctness improvements over the deprecated `do()`:

- **Request body replay** — bodies are replayed across attempts via `req.GetBody()`, cloning the request rather than mutating the caller's, mirroring `net/http.Transport`. A request whose body can't be rewound (`Body != nil && Body != http.NoBody && GetBody == nil`) is not retried, matching the stdlib's conservative behaviour. `ShouldRetry` already gates on idempotency too.
- **Connection reuse** — discarded response bodies are drained and closed before retrying; the final returned response is left readable and un-drained.
- **Cancellable backoff** — the backoff wait selects on the request context, so a cancelled request aborts the wait instead of sleeping it out.
- **Concurrency-safe** — no mutable state on the transport.

## Retry count through `WithTraces`

`DoTrace` surfaces the retry count as `Trace.Retries`. To keep that working for the recommended composition `WithTraces(WithRetries(inner))` (one trace per logical request = the final attempt), `WithRetries` increments an unexported context-carried counter that `TracesTransport` installs and reads when finalizing its trace. Composed the other way (`WithRetries(WithTraces(inner))`) each attempt is its own trace and the count is `len(traces)-1`. The chosen composition is documented on `WithRetries` and demonstrated in `TestWithRetriesAndTraces`.

## Compatibility

`Do`/`DoTrace`/`MockRequestor` are left fully intact — downstreams still use them mid-migration. No existing tests changed.

## Tests

New tests in `retries_test.go`: retry on a retryable status (503) and on `Retry-After` (429), retry on connection error, no-retry on a non-idempotent / unrewindable-body request, body replayed across attempts, max-retries-exhausted returns the last (readable) response, retry count via `WithTraces`, context cancellation, and nil-config / nil-inner pass-through. `go test ./httpx/...` (incl. `-race`) and `go vet ./httpx/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)