### PR TITLE
Update to phonenumbers v2.0.0-rc1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/lib/pq v1.11.2
 	github.com/nyaruka/librato v1.1.1
 	github.com/nyaruka/null/v3 v3.0.0
-	github.com/nyaruka/phonenumbers v1.7.0
+	github.com/nyaruka/phonenumbers/v2 v2.0.0-rc1
 	github.com/shopspring/decimal v1.4.0
 	github.com/stretchr/testify v1.11.1
 	github.com/vinovest/sqlx v1.7.2

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/nyaruka/librato v1.1.1 h1:0nTYtJLl3Sn7lX3CuHsLf+nXy1k/tGV0OjVxLy3Et4s
 github.com/nyaruka/librato v1.1.1/go.mod h1:fme1Fu1PT2qvkaBZyw8WW+SrnFe2qeeCWpvqmAaKAKE=
 github.com/nyaruka/null/v3 v3.0.0 h1:JvOiNuKmRBFHxzZFt4sWii+ewmMkCQ1vO7X0clTNn6E=
 github.com/nyaruka/null/v3 v3.0.0/go.mod h1:Sus286RmC8P0VihFuQDDQPib/xJQ7++TsaPLdRuwgVc=
-github.com/nyaruka/phonenumbers v1.7.0 h1:fiWBNIwJDvpV0HE1565fAWnBFYleaUrrrsZ+m6JgyX8=
-github.com/nyaruka/phonenumbers v1.7.0/go.mod h1:fsKPJ70O9JetEA4ggnJadYTFWwtGPvu/lETTXNXq6Cs=
+github.com/nyaruka/phonenumbers/v2 v2.0.0-rc1 h1:oJsWrmyzkMDybfMyiotF2js/CTo92pugoe672Y0kz7A=
+github.com/nyaruka/phonenumbers/v2 v2.0.0-rc1/go.mod h1:uRz+kEcEdxFvXC9KcuN+N0tMeXquLdZCrWSAV07TTEU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=

--- a/i18n/country.go
+++ b/i18n/country.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 
 	"github.com/nyaruka/null/v3"
-	"github.com/nyaruka/phonenumbers"
+	"github.com/nyaruka/phonenumbers/v2"
 )
 
 // Country is a ISO 3166-1 alpha-2 country code

--- a/urns/phone.go
+++ b/urns/phone.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/nyaruka/gocommon/i18n"
-	"github.com/nyaruka/phonenumbers"
+	"github.com/nyaruka/phonenumbers/v2"
 )
 
 var nonTelCharsRegex = regexp.MustCompile(`[^0-9A-Za-z]`)

--- a/urns/schemes.go
+++ b/urns/schemes.go
@@ -4,7 +4,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/nyaruka/phonenumbers"
+	"github.com/nyaruka/phonenumbers/v2"
 )
 
 var allDigitsRegex = regexp.MustCompile(`^[0-9]+$`)


### PR DESCRIPTION
Bumps the `phonenumbers` dependency to `v2.0.0-rc1`, which moves the module to the `/v2` import path.

## Changes
- `go.mod`/`go.sum`: `github.com/nyaruka/phonenumbers v1.7.0` → `github.com/nyaruka/phonenumbers/v2 v2.0.0-rc1`
- Updated the import path to `.../phonenumbers/v2` in `urns/phone.go`, `urns/schemes.go`, and `i18n/country.go`

## Notes for reviewers
- No call-site changes were required. The package name remains `phonenumbers`, and despite the v2 refactor (a stricter port of the upstream library), every function/constant in use kept its signature: `Parse`, `Format`, `IsPossibleNumberWithReason`, `IsPossibleShortNumberForRegion`, `GetRegionCodeForNumber`, `GetNationalNumber`, `ErrInvalidCountryCode`, `IS_POSSIBLE`, `E164`, `NATIONAL`.
- The `urns` and `i18n` packages (the only consumers) build and pass their tests.
- This pins to a release candidate (`-rc1`); worth re-pinning to the final `v2.0.0` once tagged.