### PR TITLE
Use real contexts for spool and writer flushes

### DIFF
--- a/aws/dynamo/spool.go
+++ b/aws/dynamo/spool.go
@@ -123,7 +123,7 @@ func (s *Spool) Add(table string, items []map[string]types.AttributeValue) error
 }
 
 func (s *Spool) flush() error {
-	ctx := context.TODO()
+	ctx := s.ctx
 
 	files, err := s.enumerateFiles()
 	if err != nil {

--- a/aws/dynamo/writer.go
+++ b/aws/dynamo/writer.go
@@ -94,7 +94,8 @@ func (w *Writer) Stats() (int64, int64) {
 }
 
 func (w *Writer) flush(batch []*writable) {
-	ctx := context.TODO()
+	// detached background context: this must run to completion even during batcher drain on shutdown
+	ctx := context.Background()
 
 	items := w.dedupe(batch)
 

--- a/elastic/spool.go
+++ b/elastic/spool.go
@@ -115,7 +115,7 @@ func (s *Spool) Add(docs []*Document) error {
 }
 
 func (s *Spool) flush() error {
-	ctx := context.TODO()
+	ctx := s.ctx
 
 	files, err := s.enumerateFiles()
 	if err != nil {

--- a/elastic/writer.go
+++ b/elastic/writer.go
@@ -68,7 +68,8 @@ func (w *Writer) Stats() (int64, int64) {
 }
 
 func (w *Writer) flush(batch []*Document) {
-	ctx := context.TODO()
+	// detached background context: this must run to completion even during batcher drain on shutdown
+	ctx := context.Background()
 
 	numWritten, unprocessed, err := Bulk(ctx, w.client, batch)
 	if err != nil {


### PR DESCRIPTION
Replace the placeholder `context.TODO()` in the spool and writer flush paths with appropriate real contexts.

- **Spool flushes** (dynamo + elastic): the spool already owns a cancellable lifecycle context and its background ticker loop returns on cancellation without flushing on stop, so the flush now runs under that context. An in-flight flush is cancelled on `Stop()`, and any not-yet-written items remain persisted on disk to be retried on next start.
- **Writer flushes** (dynamo + elastic): these are `syncx.Batcher` callbacks that must run to completion during the batcher's drain-on-stop, so they use an explicit `context.Background()` (with a comment) rather than a cancellable context that would abort the final batch.

No behavioral change to normal operation; this just makes the contexts explicit and correct for shutdown.
