### PR TITLE
Add centrifugo package

### DIFF
--- a/centrifugo/client.go
+++ b/centrifugo/client.go
@@ -1,0 +1,65 @@
+// Package centrifugo provides a client for the Centrifugo server API, and a mock implementation for testing.
+package centrifugo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/centrifugal/gocent/v3"
+)
+
+// Publish is a single publish of data to a channel.
+type Publish struct {
+	Channel string          `json:"channel"`
+	Data    json.RawMessage `json:"data"`
+}
+
+// Client is the interface for Centrifugo API clients, real and mock.
+type Client interface {
+	// Publish sends the given publishes to the server as a single pipelined request. If an individual publish is
+	// rejected, the returned error identifies its channel.
+	Publish(ctx context.Context, pubs ...*Publish) error
+
+	// Info checks that the server is reachable and accepts our API key.
+	Info(ctx context.Context) error
+}
+
+type client struct {
+	gc *gocent.Client
+}
+
+// NewClient creates a new client for the Centrifugo API at the given endpoint.
+func NewClient(endpoint, key string) Client {
+	return &client{gc: gocent.New(gocent.Config{Addr: endpoint, Key: key})}
+}
+
+func (c *client) Publish(ctx context.Context, pubs ...*Publish) error {
+	if len(pubs) == 0 {
+		return nil
+	}
+
+	pipe := c.gc.Pipe()
+	for _, p := range pubs {
+		if err := pipe.AddPublish(p.Channel, p.Data); err != nil {
+			return fmt.Errorf("error adding publish for channel %s: %w", p.Channel, err)
+		}
+	}
+
+	// replies are index-parallel to pubs because we add exactly one command per publish
+	replies, err := c.gc.SendPipe(ctx, pipe)
+	if err != nil {
+		return fmt.Errorf("error sending publishes: %w", err)
+	}
+	for i, reply := range replies {
+		if reply.Error != nil {
+			return fmt.Errorf("error publishing to channel %s: %w", pubs[i].Channel, reply.Error)
+		}
+	}
+	return nil
+}
+
+func (c *client) Info(ctx context.Context) error {
+	_, err := c.gc.Info(ctx)
+	return err
+}

--- a/centrifugo/client_test.go
+++ b/centrifugo/client_test.go
@@ -1,0 +1,130 @@
+package centrifugo_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nyaruka/gocommon/centrifugo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type command struct {
+	Method string          `json:"method"`
+	Params json.RawMessage `json:"params"`
+}
+
+// a fake Centrifugo API server: the client sends newline-delimited command JSON and expects one newline-delimited
+// reply per command - success replies unless error replies have been queued for the next request
+type testServer struct {
+	*httptest.Server
+
+	auths       []string    // authorization header of each request
+	requests    [][]command // commands of each request
+	nextReplies []string    // if set, the replies to the next request, instead of one {"result":{}} per command
+}
+
+func newTestServer() *testServer {
+	s := &testServer{}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.auths = append(s.auths, r.Header.Get("Authorization"))
+
+		var cmds []command
+		dec := json.NewDecoder(r.Body)
+		for {
+			var cmd command
+			if err := dec.Decode(&cmd); err == io.EOF {
+				break
+			} else if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			cmds = append(cmds, cmd)
+		}
+		s.requests = append(s.requests, cmds)
+
+		replies := s.nextReplies
+		s.nextReplies = nil
+		if replies == nil {
+			for range cmds {
+				replies = append(replies, `{"result":{}}`)
+			}
+		}
+		for _, rep := range replies {
+			io.WriteString(w, rep+"\n")
+		}
+	}))
+	return s
+}
+
+func TestClientPublish(t *testing.T) {
+	ctx := t.Context()
+
+	srv := newTestServer()
+	defer srv.Close()
+
+	c := centrifugo.NewClient(srv.URL, "sesame")
+
+	// zero publishes is a no-op that doesn't touch the server
+	require.NoError(t, c.Publish(ctx))
+	assert.Len(t, srv.requests, 0)
+
+	// a batch of publishes is sent as a single request with one command per publish, in order
+	err := c.Publish(ctx,
+		&centrifugo.Publish{Channel: "chat:general", Data: []byte(`{"text":"hi"}`)},
+		&centrifugo.Publish{Channel: "chat:random", Data: []byte(`{"text":"yo"}`)},
+		&centrifugo.Publish{Channel: "chat:general", Data: []byte(`{"text":"bye"}`)},
+	)
+	require.NoError(t, err)
+
+	require.Len(t, srv.requests, 1)
+	assert.Equal(t, "apikey sesame", srv.auths[0])
+
+	cmds := srv.requests[0]
+	require.Len(t, cmds, 3)
+	for _, cmd := range cmds {
+		assert.Equal(t, "publish", cmd.Method)
+	}
+	assert.JSONEq(t, `{"channel":"chat:general","data":{"text":"hi"}}`, string(cmds[0].Params))
+	assert.JSONEq(t, `{"channel":"chat:random","data":{"text":"yo"}}`, string(cmds[1].Params))
+	assert.JSONEq(t, `{"channel":"chat:general","data":{"text":"bye"}}`, string(cmds[2].Params))
+
+	// an error reply is attributed to the channel of the publish it corresponds to
+	srv.nextReplies = []string{`{"result":{}}`, `{"error":{"code":102,"message":"unknown channel"}}`}
+	err = c.Publish(ctx,
+		&centrifugo.Publish{Channel: "chat:general", Data: []byte(`{"text":"hi"}`)},
+		&centrifugo.Publish{Channel: "chat:nope", Data: []byte(`{"text":"yo"}`)},
+	)
+	assert.EqualError(t, err, "error publishing to channel chat:nope: unknown channel: 102")
+
+	// a non-200 response is an error
+	srv.Close()
+	err = c.Publish(ctx, &centrifugo.Publish{Channel: "chat:general", Data: []byte(`{}`)})
+	assert.ErrorContains(t, err, "error sending publishes")
+}
+
+func TestClientInfo(t *testing.T) {
+	ctx := t.Context()
+
+	srv := newTestServer()
+	defer srv.Close()
+
+	c := centrifugo.NewClient(srv.URL, "sesame")
+
+	srv.nextReplies = []string{`{"result":{"nodes":[]}}`}
+	require.NoError(t, c.Info(ctx))
+
+	require.Len(t, srv.requests, 1)
+	assert.Equal(t, "apikey sesame", srv.auths[0])
+	require.Len(t, srv.requests[0], 1)
+	assert.Equal(t, "info", srv.requests[0][0].Method)
+
+	srv.nextReplies = []string{`{"error":{"code":401,"message":"unauthorized"}}`}
+	assert.Error(t, c.Info(ctx))
+
+	srv.Close()
+	assert.Error(t, c.Info(ctx))
+}

--- a/centrifugo/mock.go
+++ b/centrifugo/mock.go
@@ -1,0 +1,86 @@
+package centrifugo
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+)
+
+// MockClient is a mock implementation of Client that records publishes in memory.
+type MockClient struct {
+	mu        sync.Mutex
+	publishes []*Publish
+	requests  int
+	err       error
+}
+
+// NewMockClient creates a new mock client.
+func NewMockClient() *MockClient {
+	return &MockClient{}
+}
+
+// Publish records the given publishes, or returns the configured error.
+func (c *MockClient) Publish(ctx context.Context, pubs ...*Publish) error {
+	if len(pubs) == 0 {
+		return nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.err != nil {
+		return c.err
+	}
+	c.publishes = append(c.publishes, pubs...)
+	c.requests++
+	return nil
+}
+
+// Info returns the configured error, if any.
+func (c *MockClient) Info(ctx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.err
+}
+
+// Published returns the data payloads published to the given channel, oldest first.
+func (c *MockClient) Published(channel string) []json.RawMessage {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var data []json.RawMessage
+	for _, p := range c.publishes {
+		if p.Channel == channel {
+			data = append(data, p.Data)
+		}
+	}
+	return data
+}
+
+// Requests returns the number of publish requests made, i.e. server round-trips.
+func (c *MockClient) Requests() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.requests
+}
+
+// SetError sets the error returned by subsequent calls.
+func (c *MockClient) SetError(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.err = err
+}
+
+// Clear removes all recorded publishes and resets the request count.
+func (c *MockClient) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.publishes = nil
+	c.requests = 0
+}
+
+var _ Client = (*MockClient)(nil)

--- a/centrifugo/mock_test.go
+++ b/centrifugo/mock_test.go
@@ -1,0 +1,48 @@
+package centrifugo_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/nyaruka/gocommon/centrifugo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMockClient(t *testing.T) {
+	ctx := t.Context()
+
+	mock := centrifugo.NewMockClient()
+
+	require.NoError(t, mock.Info(ctx))
+
+	// zero publishes is a no-op that isn't counted as a request
+	require.NoError(t, mock.Publish(ctx))
+	assert.Equal(t, 0, mock.Requests())
+
+	// each publish call is recorded as a single request, publishes readable per channel in order
+	require.NoError(t, mock.Publish(ctx,
+		&centrifugo.Publish{Channel: "chat:general", Data: []byte(`{"text":"hi"}`)},
+		&centrifugo.Publish{Channel: "chat:random", Data: []byte(`{"text":"yo"}`)},
+	))
+	require.NoError(t, mock.Publish(ctx, &centrifugo.Publish{Channel: "chat:general", Data: []byte(`{"text":"bye"}`)}))
+
+	assert.Equal(t, 2, mock.Requests())
+	assert.Equal(t, []json.RawMessage{[]byte(`{"text":"hi"}`), []byte(`{"text":"bye"}`)}, mock.Published("chat:general"))
+	assert.Equal(t, []json.RawMessage{[]byte(`{"text":"yo"}`)}, mock.Published("chat:random"))
+	assert.Empty(t, mock.Published("chat:other"))
+
+	// a configured error is returned by Publish and Info, and nothing is recorded
+	mock.SetError(errors.New("boom"))
+	assert.EqualError(t, mock.Publish(ctx, &centrifugo.Publish{Channel: "chat:general", Data: []byte(`{}`)}), "boom")
+	assert.EqualError(t, mock.Info(ctx), "boom")
+	assert.Equal(t, 2, mock.Requests())
+	assert.Len(t, mock.Published("chat:general"), 2)
+	mock.SetError(nil)
+
+	// clearing removes recorded publishes and resets the request count
+	mock.Clear()
+	assert.Equal(t, 0, mock.Requests())
+	assert.Empty(t, mock.Published("chat:general"))
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.59.2
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.104.2
 	github.com/aws/smithy-go v1.27.3
+	github.com/centrifugal/gocent/v3 v3.4.0
 	github.com/elastic/go-elasticsearch/v9 v9.4.2
 	github.com/gabriel-vasile/mimetype v1.4.13
 	github.com/go-chi/chi/v5 v5.3.0

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.43.5 h1:T3ANO8QWDbzQD8f4+UaX+fvJlyGn
 github.com/aws/aws-sdk-go-v2/service/sts v1.43.5/go.mod h1:9gdl4RrflIdpDb2TlXshWgR1F9TeCkvqDx77Vpr4Z/Q=
 github.com/aws/smithy-go v1.27.3 h1:F3Zb497UhhskkfpJmfkXswyo+t0sh9OTBnIHjogWbVY=
 github.com/aws/smithy-go v1.27.3/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/centrifugal/gocent/v3 v3.4.0 h1:RTf81vgbm5O9oOxu35w0V9e49OHVKeitu95SdN3RW9s=
+github.com/centrifugal/gocent/v3 v3.4.0/go.mod h1:8YWDQG3sX0X1g+BaotihbhawPs6zyYGUxUEk8Ng5a2g=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
Adds a `centrifugo` package providing a client for the Centrifugo server API behind a small interface, so dependent projects can mock it in tests:

* `Client` — interface with `Publish(ctx, ...*Publish)` (sent as a single pipelined request, with errors attributed to the offending channel) and `Info(ctx)` for startup health checks.
* `NewClient(endpoint, key)` — real implementation wrapping `gocent/v3`.
* `MockClient` — thread-safe in-memory implementation that records publishes, readable per channel via `Published(channel)`, with `Requests()` to assert on round-trips, plus `SetError` and `Clear`.

The real client is tested against a fake HTTP server speaking the Centrifugo API wire protocol (newline-delimited commands/replies, `apikey` auth header).