### PR TITLE
Accept business-scoped user IDs as WhatsApp URNs

### DIFF
--- a/urns/schemes.go
+++ b/urns/schemes.go
@@ -196,9 +196,19 @@ var WeChat = &Scheme{
 }
 
 var WhatsApp = &Scheme{
-	Prefix:   "whatsapp",
-	Name:     "WhatsApp",
-	Validate: func(path string) bool { return allDigitsRegex.MatchString(path) },
+	Prefix: "whatsapp",
+	Name:   "WhatsApp",
+	Normalize: func(path string) string {
+		// business-scoped user IDs have format CC.ALPHANUMERIC - uppercase the country code
+		if dot := strings.IndexByte(path, '.'); dot == 2 {
+			return strings.ToUpper(path[:dot]) + path[dot:]
+		}
+		return path
+	},
+	// a WhatsApp identity is either a phone number (all digits) or a business-scoped user ID (CC.ALPHANUMERIC)
+	Validate: func(path string) bool {
+		return allDigitsRegex.MatchString(path) || whatsAppBSUIDRegex.MatchString(path)
+	},
 }
 
 var BSUID = &Scheme{

--- a/urns/schemes.go
+++ b/urns/schemes.go
@@ -195,16 +195,19 @@ var WeChat = &Scheme{
 	Name:   "WeChat",
 }
 
+// normalizeBSUID uppercases the two-letter country code of a business-scoped user ID (format CC.ALPHANUMERIC),
+// shared by the whatsapp and bsuid schemes so they stay in lockstep
+func normalizeBSUID(path string) string {
+	if dot := strings.IndexByte(path, '.'); dot == 2 {
+		return strings.ToUpper(path[:dot]) + path[dot:]
+	}
+	return path
+}
+
 var WhatsApp = &Scheme{
-	Prefix: "whatsapp",
-	Name:   "WhatsApp",
-	Normalize: func(path string) string {
-		// business-scoped user IDs have format CC.ALPHANUMERIC - uppercase the country code
-		if dot := strings.IndexByte(path, '.'); dot == 2 {
-			return strings.ToUpper(path[:dot]) + path[dot:]
-		}
-		return path
-	},
+	Prefix:    "whatsapp",
+	Name:      "WhatsApp",
+	Normalize: normalizeBSUID,
 	// a WhatsApp identity is either a phone number (all digits) or a business-scoped user ID (CC.ALPHANUMERIC)
 	Validate: func(path string) bool {
 		return allDigitsRegex.MatchString(path) || whatsAppBSUIDRegex.MatchString(path)
@@ -212,15 +215,9 @@ var WhatsApp = &Scheme{
 }
 
 var BSUID = &Scheme{
-	Prefix: "bsuid",
-	Name:   "WhatsApp BSUID",
-	Normalize: func(path string) string {
-		// BSUIDs have format CC.ALPHANUMERIC - uppercase the country code
-		if dot := strings.IndexByte(path, '.'); dot == 2 {
-			return strings.ToUpper(path[:dot]) + path[dot:]
-		}
-		return path
-	},
+	Prefix:    "bsuid",
+	Name:      "WhatsApp BSUID",
+	Normalize: normalizeBSUID,
 	Validate: func(path string) bool {
 		return whatsAppBSUIDRegex.MatchString(path)
 	},

--- a/urns/schemes.go
+++ b/urns/schemes.go
@@ -222,3 +222,9 @@ var BSUID = &Scheme{
 		return whatsAppBSUIDRegex.MatchString(path)
 	},
 }
+
+// IsWhatsAppBSUID reports whether the URN is a WhatsApp business-scoped user ID, i.e. a whatsapp URN whose path
+// is in the CC.ALPHANUMERIC form rather than a phone number.
+func IsWhatsAppBSUID(u URN) bool {
+	return u.Scheme() == WhatsApp.Prefix && whatsAppBSUIDRegex.MatchString(u.Path())
+}

--- a/urns/urns_test.go
+++ b/urns/urns_test.go
@@ -64,6 +64,7 @@ func TestNewFromParts(t *testing.T) {
 		{urns.Instagram, "12345", nil, "", "instagram:12345", "instagram:12345", false},
 		{urns.Telegram, "12345", nil, "Jane", "telegram:12345#Jane", "telegram:12345", false},
 		{urns.WhatsApp, "12345", nil, "", "whatsapp:12345", "whatsapp:12345", false},
+		{urns.WhatsApp, "br.ABC123", nil, "", "whatsapp:BR.ABC123", "whatsapp:BR.ABC123", false}, // BSUID form normalized then validated
 		{urns.BSUID, "US.ABC123DEF", nil, "", "bsuid:US.ABC123DEF", "bsuid:US.ABC123DEF", false},
 		{urns.WebChat, "123456789012345678901234", nil, "", "webchat:123456789012345678901234", "webchat:123456789012345678901234", false},
 		{urns.WebChat, "123456789012345678901234", nil, "bob@nyaruka.com", "webchat:123456789012345678901234#bob@nyaruka.com", "webchat:123456789012345678901234", false},
@@ -122,7 +123,11 @@ func TestNormalize(t *testing.T) {
 		{"bsuid:br.ABC123", "bsuid:BR.ABC123"},
 		{"bsuid:BR.ABC123", "bsuid:BR.ABC123"},
 		{"bsuid:12345", "bsuid:12345"},
+
+		// whatsapp URNs uppercase the country code of business-scoped user IDs, but leave phone numbers untouched
 		{"whatsapp:12345", "whatsapp:12345"},
+		{"whatsapp:br.ABC123", "whatsapp:BR.ABC123"},
+		{"whatsapp:BR.ABC123", "whatsapp:BR.ABC123"},
 	}
 
 	for _, tc := range testCases {
@@ -229,14 +234,16 @@ func TestValidate(t *testing.T) {
 		{"viber:asdf!12354", "invalid path component"},
 		{"viber:xy5/5y6O81+/kbWHpLhBoA==", ""},
 
-		//whatsapp paths must be digits only
+		// whatsapp paths must be digits or a business-scoped user ID in the form CC.alphanumeric
 		{"whatsapp:12354", ""},
+		{"whatsapp:BR.1A2B3C4D5E6F7G8H9I0J", ""},
+		{"whatsapp:US.abc123DEF456", ""},
 		{"whatsapp:abcde", "invalid path component"},
 		{"whatsapp:+12067799294", "invalid path component"},
 		{"whatsapp:B.123", "invalid path component"},
 		{"whatsapp:BRA.123", "invalid path component"},
 		{"whatsapp:BR.", "invalid path component"},
-		{"whatsapp:br.ABC123", "invalid path component"},
+		{"whatsapp:br.ABC123", "invalid path component"}, // not normalized before validation, so lowercase cc is invalid
 
 		// bsuid paths must be BSUIDs in the form CC.alphanumeric
 		{"bsuid:BR.1A2B3C4D5E6F7G8H9I0J", ""},

--- a/urns/urns_test.go
+++ b/urns/urns_test.go
@@ -14,6 +14,16 @@ func TestIsValidScheme(t *testing.T) {
 	assert.False(t, urns.IsValidScheme("xyz"))
 }
 
+func TestIsWhatsAppBSUID(t *testing.T) {
+	assert.True(t, urns.IsWhatsAppBSUID("whatsapp:US.abc123"))
+	assert.True(t, urns.IsWhatsAppBSUID("whatsapp:RW.1A2B3C"))
+
+	assert.False(t, urns.IsWhatsAppBSUID("whatsapp:12065551212")) // a phone number, not a BSUID
+	assert.False(t, urns.IsWhatsAppBSUID("whatsapp:us.abc123"))   // lowercase country code isn't a valid BSUID
+	assert.False(t, urns.IsWhatsAppBSUID("bsuid:US.abc123"))      // bsuid scheme, not whatsapp
+	assert.False(t, urns.IsWhatsAppBSUID("tel:+12065551212"))
+}
+
 func TestURNProperties(t *testing.T) {
 	testCases := []struct {
 		urn      urns.URN


### PR DESCRIPTION
## What

The `whatsapp` URN scheme now validates as **either** a phone number (all digits) **or** a business-scoped user ID in `CC.ALPHANUMERIC` form, and its `Normalize` uppercases the two-letter country-code prefix (matching the existing `bsuid` behaviour).

## Why

Part of the WhatsApp channel URN "flip": the phone identity moves to a `tel:` URN and the WhatsApp business-scoped user ID becomes the canonical `whatsapp:` URN. Previously `whatsapp` validated digits-only, so `urns.New(urns.WhatsApp, "RW.abc123")` was rejected.

## Notes

- Backward compatible: plain-digit WhatsApp IDs still validate.
- Courier consumes this via a temporary `replace` directive until it's released; see the companion courier PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)