### PR TITLE
Add centrifugo.Service which layers channel subscriber tracking on a client

### DIFF
--- a/centrifugo/client.go
+++ b/centrifugo/client.go
@@ -1,4 +1,5 @@
-// Package centrifugo provides a client for the Centrifugo server API, and a mock implementation for testing.
+// Package centrifugo provides a client for the Centrifugo server API, a mock implementation for testing, and a
+// service that layers channel subscriber tracking on top of a client.
 package centrifugo
 
 import (

--- a/centrifugo/client.go
+++ b/centrifugo/client.go
@@ -10,8 +10,8 @@ import (
 	"github.com/centrifugal/gocent/v3"
 )
 
-// Publish is a single publish of data to a channel.
-type Publish struct {
+// Publication is a single publish of data to a channel.
+type Publication struct {
 	Channel string          `json:"channel"`
 	Data    json.RawMessage `json:"data"`
 }
@@ -20,7 +20,7 @@ type Publish struct {
 type Client interface {
 	// Publish sends the given publishes to the server as a single pipelined request. If an individual publish is
 	// rejected, the returned error identifies its channel.
-	Publish(ctx context.Context, pubs ...*Publish) error
+	Publish(ctx context.Context, pubs ...*Publication) error
 
 	// Info checks that the server is reachable and accepts our API key.
 	Info(ctx context.Context) error
@@ -35,7 +35,7 @@ func NewClient(endpoint, key string) Client {
 	return &client{gc: gocent.New(gocent.Config{Addr: endpoint, Key: key})}
 }
 
-func (c *client) Publish(ctx context.Context, pubs ...*Publish) error {
+func (c *client) Publish(ctx context.Context, pubs ...*Publication) error {
 	if len(pubs) == 0 {
 		return nil
 	}

--- a/centrifugo/client_test.go
+++ b/centrifugo/client_test.go
@@ -74,9 +74,9 @@ func TestClientPublish(t *testing.T) {
 
 	// a batch of publishes is sent as a single request with one command per publish, in order
 	err := c.Publish(ctx,
-		&centrifugo.Publish{Channel: "chat:general", Data: []byte(`{"text":"hi"}`)},
-		&centrifugo.Publish{Channel: "chat:random", Data: []byte(`{"text":"yo"}`)},
-		&centrifugo.Publish{Channel: "chat:general", Data: []byte(`{"text":"bye"}`)},
+		&centrifugo.Publication{Channel: "chat:general", Data: []byte(`{"text":"hi"}`)},
+		&centrifugo.Publication{Channel: "chat:random", Data: []byte(`{"text":"yo"}`)},
+		&centrifugo.Publication{Channel: "chat:general", Data: []byte(`{"text":"bye"}`)},
 	)
 	require.NoError(t, err)
 
@@ -95,14 +95,14 @@ func TestClientPublish(t *testing.T) {
 	// an error reply is attributed to the channel of the publish it corresponds to
 	srv.nextReplies = []string{`{"result":{}}`, `{"error":{"code":102,"message":"unknown channel"}}`}
 	err = c.Publish(ctx,
-		&centrifugo.Publish{Channel: "chat:general", Data: []byte(`{"text":"hi"}`)},
-		&centrifugo.Publish{Channel: "chat:nope", Data: []byte(`{"text":"yo"}`)},
+		&centrifugo.Publication{Channel: "chat:general", Data: []byte(`{"text":"hi"}`)},
+		&centrifugo.Publication{Channel: "chat:nope", Data: []byte(`{"text":"yo"}`)},
 	)
 	assert.EqualError(t, err, "error publishing to channel chat:nope: unknown channel: 102")
 
 	// a non-200 response is an error
 	srv.Close()
-	err = c.Publish(ctx, &centrifugo.Publish{Channel: "chat:general", Data: []byte(`{}`)})
+	err = c.Publish(ctx, &centrifugo.Publication{Channel: "chat:general", Data: []byte(`{}`)})
 	assert.ErrorContains(t, err, "error sending publishes")
 }
 

--- a/centrifugo/mock.go
+++ b/centrifugo/mock.go
@@ -6,10 +6,10 @@ import (
 	"sync"
 )
 
-// MockClient is a mock implementation of Client that records publishes in memory.
+// MockClient is a mock implementation of Client that records publications in memory.
 type MockClient struct {
 	mu        sync.Mutex
-	publishes []*Publication
+	publications []*Publication
 	requests  int
 	err       error
 }
@@ -19,7 +19,7 @@ func NewMockClient() *MockClient {
 	return &MockClient{}
 }
 
-// Publish records the given publishes, or returns the configured error.
+// Publish records the given publications, or returns the configured error.
 func (c *MockClient) Publish(ctx context.Context, pubs ...*Publication) error {
 	if len(pubs) == 0 {
 		return nil
@@ -31,7 +31,7 @@ func (c *MockClient) Publish(ctx context.Context, pubs ...*Publication) error {
 	if c.err != nil {
 		return c.err
 	}
-	c.publishes = append(c.publishes, pubs...)
+	c.publications = append(c.publications, pubs...)
 	c.requests++
 	return nil
 }
@@ -50,7 +50,7 @@ func (c *MockClient) Published(channel string) []json.RawMessage {
 	defer c.mu.Unlock()
 
 	var data []json.RawMessage
-	for _, p := range c.publishes {
+	for _, p := range c.publications {
 		if p.Channel == channel {
 			data = append(data, p.Data)
 		}
@@ -74,12 +74,12 @@ func (c *MockClient) SetError(err error) {
 	c.err = err
 }
 
-// Clear removes all recorded publishes and resets the request count.
+// Clear removes all recorded publications and resets the request count.
 func (c *MockClient) Clear() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.publishes = nil
+	c.publications = nil
 	c.requests = 0
 }
 

--- a/centrifugo/mock.go
+++ b/centrifugo/mock.go
@@ -3,6 +3,7 @@ package centrifugo
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"sync"
 )
 
@@ -42,6 +43,15 @@ func (c *MockClient) Info(ctx context.Context) error {
 	defer c.mu.Unlock()
 
 	return c.err
+}
+
+// Publications returns all recorded publications across all channels, oldest first. Publications marshal to JSON so
+// the entire recording can be asserted in one go, e.g. against a test fixture.
+func (c *MockClient) Publications() []*Publication {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return slices.Clone(c.publications)
 }
 
 // Published returns the data payloads published to the given channel, oldest first.

--- a/centrifugo/mock.go
+++ b/centrifugo/mock.go
@@ -2,7 +2,6 @@ package centrifugo
 
 import (
 	"context"
-	"encoding/json"
 	"slices"
 	"sync"
 )
@@ -11,7 +10,6 @@ import (
 type MockClient struct {
 	mu           sync.Mutex
 	publications []*Publication
-	requests     int
 	err          error
 }
 
@@ -33,7 +31,6 @@ func (c *MockClient) Publish(ctx context.Context, pubs ...*Publication) error {
 		return c.err
 	}
 	c.publications = append(c.publications, pubs...)
-	c.requests++
 	return nil
 }
 
@@ -54,28 +51,6 @@ func (c *MockClient) Publications() []*Publication {
 	return slices.Clone(c.publications)
 }
 
-// Published returns the data payloads published to the given channel, oldest first.
-func (c *MockClient) Published(channel string) []json.RawMessage {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	var data []json.RawMessage
-	for _, p := range c.publications {
-		if p.Channel == channel {
-			data = append(data, p.Data)
-		}
-	}
-	return data
-}
-
-// Requests returns the number of publish requests made, i.e. server round-trips.
-func (c *MockClient) Requests() int {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	return c.requests
-}
-
 // SetError sets the error returned by subsequent calls.
 func (c *MockClient) SetError(err error) {
 	c.mu.Lock()
@@ -84,13 +59,12 @@ func (c *MockClient) SetError(err error) {
 	c.err = err
 }
 
-// Clear removes all recorded publications and resets the request count.
+// Clear removes all recorded publications.
 func (c *MockClient) Clear() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	c.publications = nil
-	c.requests = 0
 }
 
 var _ Client = (*MockClient)(nil)

--- a/centrifugo/mock.go
+++ b/centrifugo/mock.go
@@ -9,7 +9,7 @@ import (
 // MockClient is a mock implementation of Client that records publishes in memory.
 type MockClient struct {
 	mu        sync.Mutex
-	publishes []*Publish
+	publishes []*Publication
 	requests  int
 	err       error
 }
@@ -20,7 +20,7 @@ func NewMockClient() *MockClient {
 }
 
 // Publish records the given publishes, or returns the configured error.
-func (c *MockClient) Publish(ctx context.Context, pubs ...*Publish) error {
+func (c *MockClient) Publish(ctx context.Context, pubs ...*Publication) error {
 	if len(pubs) == 0 {
 		return nil
 	}

--- a/centrifugo/mock.go
+++ b/centrifugo/mock.go
@@ -8,10 +8,10 @@ import (
 
 // MockClient is a mock implementation of Client that records publications in memory.
 type MockClient struct {
-	mu        sync.Mutex
+	mu           sync.Mutex
 	publications []*Publication
-	requests  int
-	err       error
+	requests     int
+	err          error
 }
 
 // NewMockClient creates a new mock client.

--- a/centrifugo/mock_test.go
+++ b/centrifugo/mock_test.go
@@ -1,7 +1,6 @@
 package centrifugo_test
 
 import (
-	"encoding/json"
 	"errors"
 	"testing"
 
@@ -18,21 +17,15 @@ func TestMockClient(t *testing.T) {
 
 	require.NoError(t, mock.Info(ctx))
 
-	// zero publishes is a no-op that isn't counted as a request
+	// zero publications is a no-op
 	require.NoError(t, mock.Publish(ctx))
-	assert.Equal(t, 0, mock.Requests())
+	assert.Empty(t, mock.Publications())
 
-	// each publish call is recorded as a single request, publishes readable per channel in order
 	require.NoError(t, mock.Publish(ctx,
 		&centrifugo.Publication{Channel: "chat:general", Data: []byte(`{"text":"hi"}`)},
 		&centrifugo.Publication{Channel: "chat:random", Data: []byte(`{"text":"yo"}`)},
 	))
 	require.NoError(t, mock.Publish(ctx, &centrifugo.Publication{Channel: "chat:general", Data: []byte(`{"text":"bye"}`)}))
-
-	assert.Equal(t, 2, mock.Requests())
-	assert.Equal(t, []json.RawMessage{[]byte(`{"text":"hi"}`), []byte(`{"text":"bye"}`)}, mock.Published("chat:general"))
-	assert.Equal(t, []json.RawMessage{[]byte(`{"text":"yo"}`)}, mock.Published("chat:random"))
-	assert.Empty(t, mock.Published("chat:other"))
 
 	// the entire recording can be asserted at once, e.g. as JSON against a fixture
 	assert.JSONEq(t, `[
@@ -45,13 +38,10 @@ func TestMockClient(t *testing.T) {
 	mock.SetError(errors.New("boom"))
 	assert.EqualError(t, mock.Publish(ctx, &centrifugo.Publication{Channel: "chat:general", Data: []byte(`{}`)}), "boom")
 	assert.EqualError(t, mock.Info(ctx), "boom")
-	assert.Equal(t, 2, mock.Requests())
-	assert.Len(t, mock.Published("chat:general"), 2)
+	assert.Len(t, mock.Publications(), 3)
 	mock.SetError(nil)
 
-	// clearing removes recorded publishes and resets the request count
+	// clearing removes recorded publications
 	mock.Clear()
-	assert.Equal(t, 0, mock.Requests())
-	assert.Empty(t, mock.Published("chat:general"))
 	assert.Empty(t, mock.Publications())
 }

--- a/centrifugo/mock_test.go
+++ b/centrifugo/mock_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/nyaruka/gocommon/centrifugo"
+	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,6 +34,13 @@ func TestMockClient(t *testing.T) {
 	assert.Equal(t, []json.RawMessage{[]byte(`{"text":"yo"}`)}, mock.Published("chat:random"))
 	assert.Empty(t, mock.Published("chat:other"))
 
+	// the entire recording can be asserted at once, e.g. as JSON against a fixture
+	assert.JSONEq(t, `[
+		{"channel": "chat:general", "data": {"text": "hi"}},
+		{"channel": "chat:random", "data": {"text": "yo"}},
+		{"channel": "chat:general", "data": {"text": "bye"}}
+	]`, string(jsonx.MustMarshal(mock.Publications())))
+
 	// a configured error is returned by Publish and Info, and nothing is recorded
 	mock.SetError(errors.New("boom"))
 	assert.EqualError(t, mock.Publish(ctx, &centrifugo.Publication{Channel: "chat:general", Data: []byte(`{}`)}), "boom")
@@ -45,4 +53,5 @@ func TestMockClient(t *testing.T) {
 	mock.Clear()
 	assert.Equal(t, 0, mock.Requests())
 	assert.Empty(t, mock.Published("chat:general"))
+	assert.Empty(t, mock.Publications())
 }

--- a/centrifugo/mock_test.go
+++ b/centrifugo/mock_test.go
@@ -23,10 +23,10 @@ func TestMockClient(t *testing.T) {
 
 	// each publish call is recorded as a single request, publishes readable per channel in order
 	require.NoError(t, mock.Publish(ctx,
-		&centrifugo.Publish{Channel: "chat:general", Data: []byte(`{"text":"hi"}`)},
-		&centrifugo.Publish{Channel: "chat:random", Data: []byte(`{"text":"yo"}`)},
+		&centrifugo.Publication{Channel: "chat:general", Data: []byte(`{"text":"hi"}`)},
+		&centrifugo.Publication{Channel: "chat:random", Data: []byte(`{"text":"yo"}`)},
 	))
-	require.NoError(t, mock.Publish(ctx, &centrifugo.Publish{Channel: "chat:general", Data: []byte(`{"text":"bye"}`)}))
+	require.NoError(t, mock.Publish(ctx, &centrifugo.Publication{Channel: "chat:general", Data: []byte(`{"text":"bye"}`)}))
 
 	assert.Equal(t, 2, mock.Requests())
 	assert.Equal(t, []json.RawMessage{[]byte(`{"text":"hi"}`), []byte(`{"text":"bye"}`)}, mock.Published("chat:general"))
@@ -35,7 +35,7 @@ func TestMockClient(t *testing.T) {
 
 	// a configured error is returned by Publish and Info, and nothing is recorded
 	mock.SetError(errors.New("boom"))
-	assert.EqualError(t, mock.Publish(ctx, &centrifugo.Publish{Channel: "chat:general", Data: []byte(`{}`)}), "boom")
+	assert.EqualError(t, mock.Publish(ctx, &centrifugo.Publication{Channel: "chat:general", Data: []byte(`{}`)}), "boom")
 	assert.EqualError(t, mock.Info(ctx), "boom")
 	assert.Equal(t, 2, mock.Requests())
 	assert.Len(t, mock.Published("chat:general"), 2)

--- a/centrifugo/service.go
+++ b/centrifugo/service.go
@@ -1,0 +1,95 @@
+package centrifugo
+
+import (
+	"context"
+	"fmt"
+
+	valkey "github.com/gomodule/redigo/redis"
+)
+
+// Service composes an API client with tracking of which channels currently have subscribers, so that publishes are
+// only actually sent to the server for channels that someone is watching.
+//
+// Subscriber tracking is presence only - whether a channel has any subscribers, not who or how many. The service
+// that authorizes channel subscriptions marks a channel as subscribed by setting a valkey key (see SubscriptionKey)
+// with a TTL, re-arming it on every subscribe and refresh - there is no unsubscribe callback so expiry of that key
+// is the only garbage collection. This service only ever reads those keys: a channel is subscribed if its key exists.
+type Service struct {
+	Client Client
+	vk     *valkey.Pool
+}
+
+// NewService creates a new service from the given API client and valkey pool.
+func NewService(client Client, vk *valkey.Pool) *Service {
+	return &Service{Client: client, vk: vk}
+}
+
+// SubscriptionKey returns the valkey key marking that the given channel has at least one active subscriber, e.g.
+// "socket-subs:chat:1234". The key name and its presence-via-existence semantics are a contract with the service
+// that authorizes subscriptions and writes these keys. Exported so tests can simulate subscribers.
+func SubscriptionKey(channel string) string {
+	return fmt.Sprintf("socket-subs:%s", channel)
+}
+
+// Subscribed returns the subset of the given channels which currently have at least one active subscriber. All
+// channels are resolved in a single round-trip by MGETting their presence keys, so checking many channels at once
+// costs one lookup rather than one per channel. The returned map only contains the subscribed channels.
+func (s *Service) Subscribed(ctx context.Context, channels ...string) (map[string]bool, error) {
+	if len(channels) == 0 {
+		return nil, nil
+	}
+
+	keys := make([]any, len(channels))
+	for i, ch := range channels {
+		keys[i] = SubscriptionKey(ch)
+	}
+
+	vc := s.vk.Get()
+	defer vc.Close()
+
+	values, err := valkey.Values(valkey.DoContext(vc, ctx, "MGET", keys...))
+	if err != nil {
+		return nil, fmt.Errorf("error checking channel subscriptions: %w", err)
+	}
+
+	subscribed := make(map[string]bool, len(channels))
+	for i, v := range values {
+		if v != nil {
+			subscribed[channels[i]] = true
+		}
+	}
+	return subscribed, nil
+}
+
+// Publish sends the given publishes to the server, skipping any whose channel has no current subscribers - such
+// publishes would be delivered to nobody so dropping them just saves the server the work. Subscriber presence for
+// all the channels is resolved in a single lookup and the surviving publishes are sent as a single pipelined
+// request, so a batch of any size costs at most two round-trips and lands or fails together.
+func (s *Service) Publish(ctx context.Context, pubs ...*Publish) error {
+	if len(pubs) == 0 {
+		return nil
+	}
+
+	channels := make([]string, 0, len(pubs))
+	seen := make(map[string]bool, len(pubs))
+	for _, p := range pubs {
+		if !seen[p.Channel] {
+			seen[p.Channel] = true
+			channels = append(channels, p.Channel)
+		}
+	}
+
+	subscribed, err := s.Subscribed(ctx, channels...)
+	if err != nil {
+		return err
+	}
+
+	send := make([]*Publish, 0, len(pubs))
+	for _, p := range pubs {
+		if subscribed[p.Channel] {
+			send = append(send, p)
+		}
+	}
+
+	return s.Client.Publish(ctx, send...)
+}

--- a/centrifugo/service.go
+++ b/centrifugo/service.go
@@ -65,7 +65,7 @@ func (s *Service) Subscribed(ctx context.Context, channels ...string) (map[strin
 // publishes would be delivered to nobody so dropping them just saves the server the work. Subscriber presence for
 // all the channels is resolved in a single lookup and the surviving publishes are sent as a single pipelined
 // request, so a batch of any size costs at most two round-trips and lands or fails together.
-func (s *Service) Publish(ctx context.Context, pubs ...*Publish) error {
+func (s *Service) Publish(ctx context.Context, pubs ...*Publication) error {
 	if len(pubs) == 0 {
 		return nil
 	}
@@ -84,7 +84,7 @@ func (s *Service) Publish(ctx context.Context, pubs ...*Publish) error {
 		return err
 	}
 
-	send := make([]*Publish, 0, len(pubs))
+	send := make([]*Publication, 0, len(pubs))
 	for _, p := range pubs {
 		if subscribed[p.Channel] {
 			send = append(send, p)

--- a/centrifugo/service.go
+++ b/centrifugo/service.go
@@ -65,6 +65,9 @@ func (s *Service) Subscribed(ctx context.Context, channels ...string) (map[strin
 // publishes would be delivered to nobody so dropping them just saves the server the work. Subscriber presence for
 // all the channels is resolved in a single lookup and the surviving publishes are sent as a single pipelined
 // request, so a batch of any size costs at most two round-trips and lands or fails together.
+//
+// Note this is inherently best-effort: presence is read before publishing, so a subscriber arriving in between
+// misses this batch. Callers should treat delivery as an optimization for live watchers, not a guarantee.
 func (s *Service) Publish(ctx context.Context, pubs ...*Publication) error {
 	if len(pubs) == 0 {
 		return nil
@@ -89,6 +92,9 @@ func (s *Service) Publish(ctx context.Context, pubs ...*Publication) error {
 		if subscribed[p.Channel] {
 			send = append(send, p)
 		}
+	}
+	if len(send) == 0 {
+		return nil
 	}
 
 	return s.Client.Publish(ctx, send...)

--- a/centrifugo/service_test.go
+++ b/centrifugo/service_test.go
@@ -5,6 +5,7 @@ import (
 
 	valkey "github.com/gomodule/redigo/redis"
 	"github.com/nyaruka/gocommon/centrifugo"
+	"github.com/nyaruka/gocommon/jsonx"
 	"github.com/nyaruka/vkutil/assertvk"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,26 +62,27 @@ func TestServicePublish(t *testing.T) {
 
 	// zero publishes is a no-op that doesn't touch valkey or the server
 	require.NoError(t, svc.Publish(ctx))
-	assert.Equal(t, 0, mock.Requests())
+	assert.Empty(t, mock.Publications())
 
 	setSubscribed(t, vk, "chat:1")
 
-	// only publishes to subscribed channels are sent, as a single request
+	// only publishes to subscribed channels are sent
 	err := svc.Publish(ctx,
 		&centrifugo.Publication{Channel: "chat:1", Data: []byte(`{"text":"hi"}`)},
 		&centrifugo.Publication{Channel: "chat:2", Data: []byte(`{"text":"yo"}`)},
 		&centrifugo.Publication{Channel: "chat:1", Data: []byte(`{"text":"bye"}`)},
 	)
 	require.NoError(t, err)
-	assert.Equal(t, 1, mock.Requests())
-	assert.Len(t, mock.Published("chat:1"), 2)
-	assert.Len(t, mock.Published("chat:2"), 0)
+	assert.JSONEq(t, `[
+		{"channel": "chat:1", "data": {"text": "hi"}},
+		{"channel": "chat:1", "data": {"text": "bye"}}
+	]`, string(jsonx.MustMarshal(mock.Publications())))
 
 	// a batch with no subscribed channels doesn't touch the server at all
 	mock.Clear()
 	err = svc.Publish(ctx, &centrifugo.Publication{Channel: "chat:2", Data: []byte(`{}`)})
 	require.NoError(t, err)
-	assert.Equal(t, 0, mock.Requests())
+	assert.Empty(t, mock.Publications())
 
 	// client errors are returned
 	mock.SetError(assert.AnError)

--- a/centrifugo/service_test.go
+++ b/centrifugo/service_test.go
@@ -1,0 +1,89 @@
+package centrifugo_test
+
+import (
+	"testing"
+
+	valkey "github.com/gomodule/redigo/redis"
+	"github.com/nyaruka/gocommon/centrifugo"
+	"github.com/nyaruka/vkutil/assertvk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// creates a pool to the standard valkey test database, flushed before each test
+func testValkeyPool(t *testing.T) *valkey.Pool {
+	vk := assertvk.TestDB()
+	t.Cleanup(func() { vk.Close() })
+
+	assertvk.FlushDB()
+
+	return vk
+}
+
+func setSubscribed(t *testing.T, vk *valkey.Pool, channel string) {
+	vc := vk.Get()
+	defer vc.Close()
+	_, err := vc.Do("SET", centrifugo.SubscriptionKey(channel), "1", "EX", 150)
+	require.NoError(t, err)
+}
+
+func TestServiceSubscribed(t *testing.T) {
+	ctx := t.Context()
+
+	vk := testValkeyPool(t)
+	svc := centrifugo.NewService(centrifugo.NewMockClient(), vk)
+
+	// zero channels is a no-op
+	subs, err := svc.Subscribed(ctx)
+	assert.NoError(t, err)
+	assert.Empty(t, subs)
+
+	// no presence keys set means nothing is subscribed
+	subs, err = svc.Subscribed(ctx, "chat:1", "chat:2")
+	assert.NoError(t, err)
+	assert.Empty(t, subs)
+
+	setSubscribed(t, vk, "chat:1")
+	setSubscribed(t, vk, "chat:3")
+
+	// only channels with presence keys come back, and all are resolved in one lookup
+	subs, err = svc.Subscribed(ctx, "chat:1", "chat:2", "chat:3")
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]bool{"chat:1": true, "chat:3": true}, subs)
+}
+
+func TestServicePublish(t *testing.T) {
+	ctx := t.Context()
+
+	vk := testValkeyPool(t)
+	mock := centrifugo.NewMockClient()
+	svc := centrifugo.NewService(mock, vk)
+
+	// zero publishes is a no-op that doesn't touch valkey or the server
+	require.NoError(t, svc.Publish(ctx))
+	assert.Equal(t, 0, mock.Requests())
+
+	setSubscribed(t, vk, "chat:1")
+
+	// only publishes to subscribed channels are sent, as a single request
+	err := svc.Publish(ctx,
+		&centrifugo.Publish{Channel: "chat:1", Data: []byte(`{"text":"hi"}`)},
+		&centrifugo.Publish{Channel: "chat:2", Data: []byte(`{"text":"yo"}`)},
+		&centrifugo.Publish{Channel: "chat:1", Data: []byte(`{"text":"bye"}`)},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, mock.Requests())
+	assert.Len(t, mock.Published("chat:1"), 2)
+	assert.Len(t, mock.Published("chat:2"), 0)
+
+	// a batch with no subscribed channels doesn't touch the server at all
+	mock.Clear()
+	err = svc.Publish(ctx, &centrifugo.Publish{Channel: "chat:2", Data: []byte(`{}`)})
+	require.NoError(t, err)
+	assert.Equal(t, 0, mock.Requests())
+
+	// client errors are returned
+	mock.SetError(assert.AnError)
+	err = svc.Publish(ctx, &centrifugo.Publish{Channel: "chat:1", Data: []byte(`{}`)})
+	assert.ErrorIs(t, err, assert.AnError)
+}

--- a/centrifugo/service_test.go
+++ b/centrifugo/service_test.go
@@ -67,9 +67,9 @@ func TestServicePublish(t *testing.T) {
 
 	// only publishes to subscribed channels are sent, as a single request
 	err := svc.Publish(ctx,
-		&centrifugo.Publish{Channel: "chat:1", Data: []byte(`{"text":"hi"}`)},
-		&centrifugo.Publish{Channel: "chat:2", Data: []byte(`{"text":"yo"}`)},
-		&centrifugo.Publish{Channel: "chat:1", Data: []byte(`{"text":"bye"}`)},
+		&centrifugo.Publication{Channel: "chat:1", Data: []byte(`{"text":"hi"}`)},
+		&centrifugo.Publication{Channel: "chat:2", Data: []byte(`{"text":"yo"}`)},
+		&centrifugo.Publication{Channel: "chat:1", Data: []byte(`{"text":"bye"}`)},
 	)
 	require.NoError(t, err)
 	assert.Equal(t, 1, mock.Requests())
@@ -78,12 +78,12 @@ func TestServicePublish(t *testing.T) {
 
 	// a batch with no subscribed channels doesn't touch the server at all
 	mock.Clear()
-	err = svc.Publish(ctx, &centrifugo.Publish{Channel: "chat:2", Data: []byte(`{}`)})
+	err = svc.Publish(ctx, &centrifugo.Publication{Channel: "chat:2", Data: []byte(`{}`)})
 	require.NoError(t, err)
 	assert.Equal(t, 0, mock.Requests())
 
 	// client errors are returned
 	mock.SetError(assert.AnError)
-	err = svc.Publish(ctx, &centrifugo.Publish{Channel: "chat:1", Data: []byte(`{}`)})
+	err = svc.Publish(ctx, &centrifugo.Publication{Channel: "chat:1", Data: []byte(`{}`)})
 	assert.ErrorIs(t, err, assert.AnError)
 }

--- a/centrifugo/service_test.go
+++ b/centrifugo/service_test.go
@@ -88,4 +88,16 @@ func TestServicePublish(t *testing.T) {
 	mock.SetError(assert.AnError)
 	err = svc.Publish(ctx, &centrifugo.Publication{Channel: "chat:1", Data: []byte(`{}`)})
 	assert.ErrorIs(t, err, assert.AnError)
+	mock.SetError(nil)
+
+	// a valkey error during the presence lookup is returned and nothing is published
+	badVK := &valkey.Pool{
+		Dial: func() (valkey.Conn, error) { return valkey.Dial("tcp", "localhost:1") },
+	}
+	defer badVK.Close()
+
+	badSvc := centrifugo.NewService(mock, badVK)
+	err = badSvc.Publish(ctx, &centrifugo.Publication{Channel: "chat:1", Data: []byte(`{}`)})
+	assert.ErrorContains(t, err, "error checking channel subscriptions")
+	assert.Empty(t, mock.Publications())
 }

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.13
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/go-playground/validator/v10 v10.30.3
+	github.com/gomodule/redigo v1.9.3
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/jellydator/ttlcache/v3 v3.4.1
@@ -22,6 +23,7 @@ require (
 	github.com/nyaruka/librato v1.1.1
 	github.com/nyaruka/null/v3 v3.0.0
 	github.com/nyaruka/phonenumbers/v2 v2.0.2
+	github.com/nyaruka/vkutil v0.21.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/stretchr/testify v1.11.1
 	github.com/vinovest/sqlx v1.7.2

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/go-playground/validator/v10 v10.30.3 h1:4MU6YkEwx7GbcPJOZxrtbu+QfF3pJ
 github.com/go-playground/validator/v10 v10.30.3/go.mod h1:4Axh7oCNGcoGkqLoE4YWt6n20mcEIsPRlB7vPk3lpyc=
 github.com/go-sql-driver/mysql v1.9.0 h1:Y0zIbQXhQKmQgTp44Y1dp3wTXcn804QoTptLZT1vtvo=
 github.com/go-sql-driver/mysql v1.9.0/go.mod h1:pDetrLJeA3oMujJuvXc8RJoasr589B6A9fwzD3QMrqw=
+github.com/gomodule/redigo v1.9.3 h1:dNPSXeXv6HCq2jdyWfjgmhBdqnR6PRO3m/G05nvpPC8=
+github.com/gomodule/redigo v1.9.3/go.mod h1:KsU3hiK/Ay8U42qpaJk+kuNa3C+spxapWpM+ywhcgtw=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -103,6 +105,8 @@ github.com/nyaruka/null/v3 v3.0.0 h1:JvOiNuKmRBFHxzZFt4sWii+ewmMkCQ1vO7X0clTNn6E
 github.com/nyaruka/null/v3 v3.0.0/go.mod h1:Sus286RmC8P0VihFuQDDQPib/xJQ7++TsaPLdRuwgVc=
 github.com/nyaruka/phonenumbers/v2 v2.0.2 h1:8+XJFJcApk+rKNi/pbK1WeyH1p6XmLx2UNT9eGDqI90=
 github.com/nyaruka/phonenumbers/v2 v2.0.2/go.mod h1:pKu+U8m/6xzgPlYxQ9D89irpcWeB4/J7lKd3FbhQaqw=
+github.com/nyaruka/vkutil v0.21.0 h1:Vy1auqZ2slCQ1H6t/texGLv8v5DObwtwTFW7OLid9Ok=
+github.com/nyaruka/vkutil v0.21.0/go.mod h1:5dIAvwkeidExJWAJ5AAYlYN8PJ4MQrzJeFuO8wRdlAo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=


### PR DESCRIPTION
## What

Adds `centrifugo.Service`, which composes a centrifugo API `Client` with tracking of which channels currently have subscribers:

- `Subscribed(ctx, channels...)` returns the subset of the given channels that have at least one active subscriber, resolved in a single MGET regardless of how many channels are checked.
- `Publish(ctx, pubs...)` sends publishes to the server but silently skips any whose channel has no current subscribers - such publishes would be delivered to nobody, so dropping them saves the server round-trip. A batch of any size costs at most two round-trips (one presence lookup + one pipelined publish) and lands or fails together.
- `SubscriptionKey(channel)` is exported and documents the `socket-subs:<channel>` presence key contract: the service that authorizes subscriptions sets the key with a TTL (re-armed on every subscribe/refresh, expiry being the only GC), and this service only ever reads it.

## Why

Consumers of this library each carried their own copy of the presence-key reader and the filter-then-pipeline publish logic. Moving it here gives that contract a single canonical home on the publishing side.

## Notes for review

- `Service` keeps `Client` as an exported interface field, so `MockClient` continues to work unchanged for testing publish behavior, while presence checks go against a real valkey in tests.
- New dependencies: `gomodule/redigo` (direct, for the presence lookup) and `nyaruka/vkutil` v0.21.0 (test-only, for its `assertvk` test database helpers). vkutil no longer depends on gocommon as of v0.21.0, so this doesn't introduce a module cycle.