### PR TITLE
Marshal centrifugo publication data at send time

### DIFF
--- a/centrifugo/client.go
+++ b/centrifugo/client.go
@@ -10,24 +10,13 @@ import (
 	"github.com/centrifugal/gocent/v3"
 )
 
-// Publication is a single publish of data to a channel. Data can be pre-marshaled JSON (json.RawMessage or []byte)
-// or any JSON marshal-able value - the latter is only marshaled when the publication is actually sent, so callers
-// can defer the marshaling cost of publications that end up dropped (see Service.Publish).
+// Publication is a single publish of data to a channel. Data can be any JSON marshal-able value and is only
+// marshaled when the publication is actually sent, so callers can defer the marshaling cost of publications that
+// end up dropped (see Service.Publish). Pre-marshaled JSON should be typed as json.RawMessage - a plain []byte
+// would be marshaled as a base64 string.
 type Publication struct {
 	Channel string `json:"channel"`
 	Data    any    `json:"data"`
-}
-
-// marshaledData returns the data as JSON, marshaling it if it isn't already marshaled.
-func (p *Publication) marshaledData() (json.RawMessage, error) {
-	switch typed := p.Data.(type) {
-	case json.RawMessage:
-		return typed, nil
-	case []byte:
-		return typed, nil
-	default:
-		return json.Marshal(p.Data)
-	}
 }
 
 // Client is the interface for Centrifugo API clients, real and mock.
@@ -56,7 +45,7 @@ func (c *client) Publish(ctx context.Context, pubs ...*Publication) error {
 
 	pipe := c.gc.Pipe()
 	for _, p := range pubs {
-		data, err := p.marshaledData()
+		data, err := json.Marshal(p.Data)
 		if err != nil {
 			return fmt.Errorf("error marshaling data for channel %s: %w", p.Channel, err)
 		}

--- a/centrifugo/client.go
+++ b/centrifugo/client.go
@@ -10,10 +10,24 @@ import (
 	"github.com/centrifugal/gocent/v3"
 )
 
-// Publication is a single publish of data to a channel.
+// Publication is a single publish of data to a channel. Data can be pre-marshaled JSON (json.RawMessage or []byte)
+// or any JSON marshal-able value - the latter is only marshaled when the publication is actually sent, so callers
+// can defer the marshaling cost of publications that end up dropped (see Service.Publish).
 type Publication struct {
-	Channel string          `json:"channel"`
-	Data    json.RawMessage `json:"data"`
+	Channel string `json:"channel"`
+	Data    any    `json:"data"`
+}
+
+// marshaledData returns the data as JSON, marshaling it if it isn't already marshaled.
+func (p *Publication) marshaledData() (json.RawMessage, error) {
+	switch typed := p.Data.(type) {
+	case json.RawMessage:
+		return typed, nil
+	case []byte:
+		return typed, nil
+	default:
+		return json.Marshal(p.Data)
+	}
 }
 
 // Client is the interface for Centrifugo API clients, real and mock.
@@ -42,7 +56,11 @@ func (c *client) Publish(ctx context.Context, pubs ...*Publication) error {
 
 	pipe := c.gc.Pipe()
 	for _, p := range pubs {
-		if err := pipe.AddPublish(p.Channel, p.Data); err != nil {
+		data, err := p.marshaledData()
+		if err != nil {
+			return fmt.Errorf("error marshaling data for channel %s: %w", p.Channel, err)
+		}
+		if err := pipe.AddPublish(p.Channel, data); err != nil {
 			return fmt.Errorf("error adding publish for channel %s: %w", p.Channel, err)
 		}
 	}

--- a/centrifugo/client_test.go
+++ b/centrifugo/client_test.go
@@ -92,6 +92,19 @@ func TestClientPublish(t *testing.T) {
 	assert.JSONEq(t, `{"channel":"chat:random","data":{"text":"yo"}}`, string(cmds[1].Params))
 	assert.JSONEq(t, `{"channel":"chat:general","data":{"text":"bye"}}`, string(cmds[2].Params))
 
+	// data that isn't already marshaled is marshaled at send time
+	err = c.Publish(ctx, &centrifugo.Publication{Channel: "chat:general", Data: map[string]any{"text": "hola"}})
+	require.NoError(t, err)
+	require.Len(t, srv.requests, 2)
+	cmds = srv.requests[1]
+	require.Len(t, cmds, 1)
+	assert.JSONEq(t, `{"channel":"chat:general","data":{"text":"hola"}}`, string(cmds[0].Params))
+
+	// unmarshalable data is an error identifying the channel, and nothing is sent
+	err = c.Publish(ctx, &centrifugo.Publication{Channel: "chat:bad", Data: func() {}})
+	assert.ErrorContains(t, err, "error marshaling data for channel chat:bad")
+	assert.Len(t, srv.requests, 2)
+
 	// an error reply is attributed to the channel of the publish it corresponds to
 	srv.nextReplies = []string{`{"result":{}}`, `{"error":{"code":102,"message":"unknown channel"}}`}
 	err = c.Publish(ctx,

--- a/centrifugo/client_test.go
+++ b/centrifugo/client_test.go
@@ -74,9 +74,9 @@ func TestClientPublish(t *testing.T) {
 
 	// a batch of publishes is sent as a single request with one command per publish, in order
 	err := c.Publish(ctx,
-		&centrifugo.Publication{Channel: "chat:general", Data: []byte(`{"text":"hi"}`)},
-		&centrifugo.Publication{Channel: "chat:random", Data: []byte(`{"text":"yo"}`)},
-		&centrifugo.Publication{Channel: "chat:general", Data: []byte(`{"text":"bye"}`)},
+		&centrifugo.Publication{Channel: "chat:general", Data: json.RawMessage(`{"text":"hi"}`)},
+		&centrifugo.Publication{Channel: "chat:random", Data: json.RawMessage(`{"text":"yo"}`)},
+		&centrifugo.Publication{Channel: "chat:general", Data: json.RawMessage(`{"text":"bye"}`)},
 	)
 	require.NoError(t, err)
 
@@ -108,14 +108,14 @@ func TestClientPublish(t *testing.T) {
 	// an error reply is attributed to the channel of the publish it corresponds to
 	srv.nextReplies = []string{`{"result":{}}`, `{"error":{"code":102,"message":"unknown channel"}}`}
 	err = c.Publish(ctx,
-		&centrifugo.Publication{Channel: "chat:general", Data: []byte(`{"text":"hi"}`)},
-		&centrifugo.Publication{Channel: "chat:nope", Data: []byte(`{"text":"yo"}`)},
+		&centrifugo.Publication{Channel: "chat:general", Data: json.RawMessage(`{"text":"hi"}`)},
+		&centrifugo.Publication{Channel: "chat:nope", Data: json.RawMessage(`{"text":"yo"}`)},
 	)
 	assert.EqualError(t, err, "error publishing to channel chat:nope: unknown channel: 102")
 
 	// a non-200 response is an error
 	srv.Close()
-	err = c.Publish(ctx, &centrifugo.Publication{Channel: "chat:general", Data: []byte(`{}`)})
+	err = c.Publish(ctx, &centrifugo.Publication{Channel: "chat:general", Data: json.RawMessage(`{}`)})
 	assert.ErrorContains(t, err, "error sending publishes")
 }
 

--- a/centrifugo/mock.go
+++ b/centrifugo/mock.go
@@ -33,13 +33,17 @@ func (c *MockClient) Publish(ctx context.Context, pubs ...*Publication) error {
 	if c.err != nil {
 		return c.err
 	}
-	for _, p := range pubs {
+
+	// marshal everything before recording anything - like the real client, a batch with a marshal error sends nothing
+	recorded := make([]*Publication, len(pubs))
+	for i, p := range pubs {
 		data, err := json.Marshal(p.Data)
 		if err != nil {
 			return fmt.Errorf("error marshaling data for channel %s: %w", p.Channel, err)
 		}
-		c.publications = append(c.publications, &Publication{Channel: p.Channel, Data: json.RawMessage(data)})
+		recorded[i] = &Publication{Channel: p.Channel, Data: json.RawMessage(data)}
 	}
+	c.publications = append(c.publications, recorded...)
 	return nil
 }
 

--- a/centrifugo/mock.go
+++ b/centrifugo/mock.go
@@ -2,6 +2,8 @@ package centrifugo
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"slices"
 	"sync"
 )
@@ -18,7 +20,8 @@ func NewMockClient() *MockClient {
 	return &MockClient{}
 }
 
-// Publish records the given publications, or returns the configured error.
+// Publish records the given publications, or returns the configured error. Like the real client it marshals each
+// publication's data at this point, so what's recorded is the JSON that would have been sent.
 func (c *MockClient) Publish(ctx context.Context, pubs ...*Publication) error {
 	if len(pubs) == 0 {
 		return nil
@@ -30,7 +33,13 @@ func (c *MockClient) Publish(ctx context.Context, pubs ...*Publication) error {
 	if c.err != nil {
 		return c.err
 	}
-	c.publications = append(c.publications, pubs...)
+	for _, p := range pubs {
+		data, err := p.marshaledData()
+		if err != nil {
+			return fmt.Errorf("error marshaling data for channel %s: %w", p.Channel, err)
+		}
+		c.publications = append(c.publications, &Publication{Channel: p.Channel, Data: json.RawMessage(data)})
+	}
 	return nil
 }
 

--- a/centrifugo/mock.go
+++ b/centrifugo/mock.go
@@ -34,7 +34,7 @@ func (c *MockClient) Publish(ctx context.Context, pubs ...*Publication) error {
 		return c.err
 	}
 	for _, p := range pubs {
-		data, err := p.marshaledData()
+		data, err := json.Marshal(p.Data)
 		if err != nil {
 			return fmt.Errorf("error marshaling data for channel %s: %w", p.Channel, err)
 		}

--- a/centrifugo/mock_test.go
+++ b/centrifugo/mock_test.go
@@ -1,6 +1,7 @@
 package centrifugo_test
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -27,18 +28,27 @@ func TestMockClient(t *testing.T) {
 	))
 	require.NoError(t, mock.Publish(ctx, &centrifugo.Publication{Channel: "chat:general", Data: []byte(`{"text":"bye"}`)}))
 
+	// unmarshaled data is marshaled when recorded, like the real client marshals when sending
+	require.NoError(t, mock.Publish(ctx, &centrifugo.Publication{Channel: "chat:general", Data: map[string]any{"text": "hola"}}))
+	assert.Equal(t, json.RawMessage(`{"text":"hola"}`), mock.Publications()[3].Data)
+
 	// the entire recording can be asserted at once, e.g. as JSON against a fixture
 	assert.JSONEq(t, `[
 		{"channel": "chat:general", "data": {"text": "hi"}},
 		{"channel": "chat:random", "data": {"text": "yo"}},
-		{"channel": "chat:general", "data": {"text": "bye"}}
+		{"channel": "chat:general", "data": {"text": "bye"}},
+		{"channel": "chat:general", "data": {"text": "hola"}}
 	]`, string(jsonx.MustMarshal(mock.Publications())))
+
+	// unmarshalable data is an error identifying the channel, and nothing is recorded
+	assert.ErrorContains(t, mock.Publish(ctx, &centrifugo.Publication{Channel: "chat:bad", Data: func() {}}), "error marshaling data for channel chat:bad")
+	assert.Len(t, mock.Publications(), 4)
 
 	// a configured error is returned by Publish and Info, and nothing is recorded
 	mock.SetError(errors.New("boom"))
 	assert.EqualError(t, mock.Publish(ctx, &centrifugo.Publication{Channel: "chat:general", Data: []byte(`{}`)}), "boom")
 	assert.EqualError(t, mock.Info(ctx), "boom")
-	assert.Len(t, mock.Publications(), 3)
+	assert.Len(t, mock.Publications(), 4)
 	mock.SetError(nil)
 
 	// clearing removes recorded publications

--- a/centrifugo/mock_test.go
+++ b/centrifugo/mock_test.go
@@ -23,10 +23,10 @@ func TestMockClient(t *testing.T) {
 	assert.Empty(t, mock.Publications())
 
 	require.NoError(t, mock.Publish(ctx,
-		&centrifugo.Publication{Channel: "chat:general", Data: []byte(`{"text":"hi"}`)},
-		&centrifugo.Publication{Channel: "chat:random", Data: []byte(`{"text":"yo"}`)},
+		&centrifugo.Publication{Channel: "chat:general", Data: json.RawMessage(`{"text":"hi"}`)},
+		&centrifugo.Publication{Channel: "chat:random", Data: json.RawMessage(`{"text":"yo"}`)},
 	))
-	require.NoError(t, mock.Publish(ctx, &centrifugo.Publication{Channel: "chat:general", Data: []byte(`{"text":"bye"}`)}))
+	require.NoError(t, mock.Publish(ctx, &centrifugo.Publication{Channel: "chat:general", Data: json.RawMessage(`{"text":"bye"}`)}))
 
 	// unmarshaled data is marshaled when recorded, like the real client marshals when sending
 	require.NoError(t, mock.Publish(ctx, &centrifugo.Publication{Channel: "chat:general", Data: map[string]any{"text": "hola"}}))
@@ -46,7 +46,7 @@ func TestMockClient(t *testing.T) {
 
 	// a configured error is returned by Publish and Info, and nothing is recorded
 	mock.SetError(errors.New("boom"))
-	assert.EqualError(t, mock.Publish(ctx, &centrifugo.Publication{Channel: "chat:general", Data: []byte(`{}`)}), "boom")
+	assert.EqualError(t, mock.Publish(ctx, &centrifugo.Publication{Channel: "chat:general", Data: json.RawMessage(`{}`)}), "boom")
 	assert.EqualError(t, mock.Info(ctx), "boom")
 	assert.Len(t, mock.Publications(), 4)
 	mock.SetError(nil)

--- a/centrifugo/mock_test.go
+++ b/centrifugo/mock_test.go
@@ -40,8 +40,13 @@ func TestMockClient(t *testing.T) {
 		{"channel": "chat:general", "data": {"text": "hola"}}
 	]`, string(jsonx.MustMarshal(mock.Publications())))
 
-	// unmarshalable data is an error identifying the channel, and nothing is recorded
-	assert.ErrorContains(t, mock.Publish(ctx, &centrifugo.Publication{Channel: "chat:bad", Data: func() {}}), "error marshaling data for channel chat:bad")
+	// unmarshalable data is an error identifying the channel, and nothing is recorded - even for other publications
+	// in the same batch, matching the real client which sends nothing if any publication fails to marshal
+	err := mock.Publish(ctx,
+		&centrifugo.Publication{Channel: "chat:general", Data: json.RawMessage(`{"text":"lost"}`)},
+		&centrifugo.Publication{Channel: "chat:bad", Data: func() {}},
+	)
+	assert.ErrorContains(t, err, "error marshaling data for channel chat:bad")
 	assert.Len(t, mock.Publications(), 4)
 
 	// a configured error is returned by Publish and Info, and nothing is recorded

--- a/centrifugo/service.go
+++ b/centrifugo/service.go
@@ -64,7 +64,8 @@ func (s *Service) Subscribed(ctx context.Context, channels ...string) (map[strin
 // Publish sends the given publishes to the server, skipping any whose channel has no current subscribers - such
 // publishes would be delivered to nobody so dropping them just saves the server the work. Subscriber presence for
 // all the channels is resolved in a single lookup and the surviving publishes are sent as a single pipelined
-// request, so a batch of any size costs at most two round-trips and lands or fails together.
+// request, so a batch of any size costs at most two round-trips and lands or fails together. Because data is only
+// marshaled at send time, callers can pass unmarshaled values and dropped publishes never pay the marshaling cost.
 //
 // Note this is inherently best-effort: presence is read before publishing, so a subscriber arriving in between
 // misses this batch. Callers should treat delivery as an optimization for live watchers, not a guarantee.

--- a/centrifugo/service_test.go
+++ b/centrifugo/service_test.go
@@ -84,6 +84,12 @@ func TestServicePublish(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, mock.Publications())
 
+	// and because marshaling only happens at send time, dropped publishes never pay for it - even unmarshalable
+	// data isn't an error when nobody is subscribed to its channel
+	err = svc.Publish(ctx, &centrifugo.Publication{Channel: "chat:2", Data: func() {}})
+	require.NoError(t, err)
+	assert.Empty(t, mock.Publications())
+
 	// client errors are returned
 	mock.SetError(assert.AnError)
 	err = svc.Publish(ctx, &centrifugo.Publication{Channel: "chat:1", Data: []byte(`{}`)})

--- a/centrifugo/service_test.go
+++ b/centrifugo/service_test.go
@@ -1,6 +1,7 @@
 package centrifugo_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	valkey "github.com/gomodule/redigo/redis"
@@ -68,9 +69,9 @@ func TestServicePublish(t *testing.T) {
 
 	// only publishes to subscribed channels are sent
 	err := svc.Publish(ctx,
-		&centrifugo.Publication{Channel: "chat:1", Data: []byte(`{"text":"hi"}`)},
-		&centrifugo.Publication{Channel: "chat:2", Data: []byte(`{"text":"yo"}`)},
-		&centrifugo.Publication{Channel: "chat:1", Data: []byte(`{"text":"bye"}`)},
+		&centrifugo.Publication{Channel: "chat:1", Data: json.RawMessage(`{"text":"hi"}`)},
+		&centrifugo.Publication{Channel: "chat:2", Data: json.RawMessage(`{"text":"yo"}`)},
+		&centrifugo.Publication{Channel: "chat:1", Data: json.RawMessage(`{"text":"bye"}`)},
 	)
 	require.NoError(t, err)
 	assert.JSONEq(t, `[
@@ -80,7 +81,7 @@ func TestServicePublish(t *testing.T) {
 
 	// a batch with no subscribed channels doesn't touch the server at all
 	mock.Clear()
-	err = svc.Publish(ctx, &centrifugo.Publication{Channel: "chat:2", Data: []byte(`{}`)})
+	err = svc.Publish(ctx, &centrifugo.Publication{Channel: "chat:2", Data: json.RawMessage(`{}`)})
 	require.NoError(t, err)
 	assert.Empty(t, mock.Publications())
 
@@ -92,7 +93,7 @@ func TestServicePublish(t *testing.T) {
 
 	// client errors are returned
 	mock.SetError(assert.AnError)
-	err = svc.Publish(ctx, &centrifugo.Publication{Channel: "chat:1", Data: []byte(`{}`)})
+	err = svc.Publish(ctx, &centrifugo.Publication{Channel: "chat:1", Data: json.RawMessage(`{}`)})
 	assert.ErrorIs(t, err, assert.AnError)
 	mock.SetError(nil)
 
@@ -103,7 +104,7 @@ func TestServicePublish(t *testing.T) {
 	defer badVK.Close()
 
 	badSvc := centrifugo.NewService(mock, badVK)
-	err = badSvc.Publish(ctx, &centrifugo.Publication{Channel: "chat:1", Data: []byte(`{}`)})
+	err = badSvc.Publish(ctx, &centrifugo.Publication{Channel: "chat:1", Data: json.RawMessage(`{}`)})
 	assert.ErrorContains(t, err, "error checking channel subscriptions")
 	assert.Empty(t, mock.Publications())
 }


### PR DESCRIPTION
Changes `centrifugo.Publication.Data` from `json.RawMessage` to `any`, marshaled by the client only when the publication is actually sent. Pre-marshaled JSON still works — `json.Marshal` passes a `json.RawMessage` through unchanged — it just needs to be typed as `json.RawMessage` (a plain `[]byte` would be marshaled as a base64 string, which the doc comment calls out).

Since `Service.Publish` drops publications to channels with no subscribers *before* they reach the client, callers can now pass unmarshaled values and dropped publications never pay the marshaling cost. That matters for callers that publish on hot paths where subscribers are usually absent — previously they had to marshal every payload up front just to have the presence filter throw it away.

`MockClient.Publish` marshals data when recording (mirroring the real client marshaling when sending), so `Publications()` still returns canonical JSON bytes and fixture-style `JSONEq` assertions keep working.

A marshal failure returns an error identifying the channel, consistent with the existing per-channel publish errors — and only for publications that survive the presence filter, since dropped ones are never marshaled.