### PR TITLE
Verify dynamo spool directory is writable on start

### DIFF
--- a/aws/dynamo/spool.go
+++ b/aws/dynamo/spool.go
@@ -56,6 +56,14 @@ func (s *Spool) Start() error {
 		return fmt.Errorf("error creating spool directory %s: %w", s.directory, err)
 	}
 
+	// MkdirAll succeeds if directory already exists even if it's not writable, so probe actual writability
+	probe, err := os.CreateTemp(s.directory, ".probe-*")
+	if err != nil {
+		return fmt.Errorf("spool directory %s is not writable: %w", s.directory, err)
+	}
+	probe.Close()
+	os.Remove(probe.Name())
+
 	// enumerate existing files to get current size
 	files, err := s.enumerateFiles()
 	if err != nil {

--- a/aws/dynamo/spool_test.go
+++ b/aws/dynamo/spool_test.go
@@ -1,6 +1,8 @@
 package dynamo_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -11,6 +13,7 @@ import (
 	"github.com/nyaruka/gocommon/dates"
 	"github.com/nyaruka/gocommon/uuids"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSpool(t *testing.T) {
@@ -62,4 +65,27 @@ func TestSpool(t *testing.T) {
 	assert.Equal(t, "Thing 1", obj.Data["name"])
 
 	spool.Stop()
+}
+
+func TestSpoolStartDirectoryErrors(t *testing.T) {
+	// a file in place of the directory means it can't be created
+	notADir := filepath.Join(t.TempDir(), "spool")
+	require.NoError(t, os.WriteFile(notADir, []byte("!"), 0644))
+
+	spool := dynamo.NewSpool(nil, notADir, 30*time.Second)
+	err := spool.Start()
+	assert.ErrorContains(t, err, "error creating spool directory")
+
+	// an existing but unwritable directory should fail the writability probe.. but skip if running as
+	// root because then permission bits are ignored
+	if os.Geteuid() == 0 {
+		t.Skip("running as root so can't test unwritable directory")
+	}
+
+	unwritable := filepath.Join(t.TempDir(), "spool")
+	require.NoError(t, os.Mkdir(unwritable, 0555))
+
+	spool = dynamo.NewSpool(nil, unwritable, 30*time.Second)
+	err = spool.Start()
+	assert.ErrorContains(t, err, "is not writable")
 }

--- a/elastic/spool.go
+++ b/elastic/spool.go
@@ -54,6 +54,14 @@ func (s *Spool) Start() error {
 		return fmt.Errorf("error creating spool directory %s: %w", s.directory, err)
 	}
 
+	// MkdirAll succeeds if directory already exists even if it's not writable, so probe actual writability
+	probe, err := os.CreateTemp(s.directory, ".probe-*")
+	if err != nil {
+		return fmt.Errorf("spool directory %s is not writable: %w", s.directory, err)
+	}
+	probe.Close()
+	os.Remove(probe.Name())
+
 	// enumerate existing files to get current size
 	files, err := s.enumerateFiles()
 	if err != nil {

--- a/elastic/spool_test.go
+++ b/elastic/spool_test.go
@@ -1,6 +1,8 @@
 package elastic_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -58,4 +60,27 @@ func TestSpool(t *testing.T) {
 	assertCount(t, testClient, "test-spool", 3)
 
 	spool.Stop()
+}
+
+func TestSpoolStartDirectoryErrors(t *testing.T) {
+	// a file in place of the directory means it can't be created
+	notADir := filepath.Join(t.TempDir(), "spool")
+	require.NoError(t, os.WriteFile(notADir, []byte("!"), 0644))
+
+	spool := elastic.NewSpool(nil, notADir, 30*time.Second)
+	err := spool.Start()
+	assert.ErrorContains(t, err, "error creating spool directory")
+
+	// an existing but unwritable directory should fail the writability probe.. but skip if running as
+	// root because then permission bits are ignored
+	if os.Geteuid() == 0 {
+		t.Skip("running as root so can't test unwritable directory")
+	}
+
+	unwritable := filepath.Join(t.TempDir(), "spool")
+	require.NoError(t, os.Mkdir(unwritable, 0555))
+
+	spool = elastic.NewSpool(nil, unwritable, 30*time.Second)
+	err = spool.Start()
+	assert.ErrorContains(t, err, "is not writable")
 }


### PR DESCRIPTION
`Spool.Start()` ensures its directory exists with `os.MkdirAll`, but that succeeds when the directory already exists even if it's unwritable (e.g. a read-only mount). A service would then start cleanly and only fail in `Spool.Add()` at write time — during a DynamoDB outage, exactly when the spool is needed.

This probes actual writability in `Start()` by creating and removing a temp file in the spool directory, returning a wrapped error on failure so misconfiguration is caught at startup.

The probe file pattern (`.probe-*`) can never be picked up by flushing since `enumerateFiles` only matches `<uuid>#<count>@<table>.jsonl` names.

Tests cover both failure paths: a file in place of the directory (works even when tests run as root) and an unwritable directory (skipped when running as root, where permission bits are ignored).