### PR TITLE
Extract generic file-backed spool package

### DIFF
--- a/aws/dynamo/spool.go
+++ b/aws/dynamo/spool.go
@@ -78,6 +78,11 @@ func (s *Spool) Add(table string, items []map[string]types.AttributeValue) error
 	return s.spool.Add(batch)
 }
 
+// Flush performs an immediate flush of all spooled files - see [spool.Spool.Flush].
+func (s *Spool) Flush() error {
+	return s.spool.Flush()
+}
+
 // Size returns the number of items currently spooled.
 func (s *Spool) Size() int {
 	return s.spool.Size()

--- a/aws/dynamo/spool.go
+++ b/aws/dynamo/spool.go
@@ -1,226 +1,114 @@
 package dynamo
 
 import (
-	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
-	"log/slog"
-	"os"
-	"regexp"
-	"strconv"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
-	"github.com/nyaruka/gocommon/uuids"
+	"github.com/nyaruka/gocommon/spool"
 )
 
-type spooledFile struct {
-	path  string
-	count int
+// spooled is a DynamoDB item and the table it's destined for.
+type spooled struct {
 	table string
+	item  map[string]types.AttributeValue
 }
 
-var spooledFileRegex = regexp.MustCompile(`^[^@]+#(\d+)@(\w+)\.jsonl$`) // <uuid>#<count>@<table>.jsonl
+// spooledJSON is the serialized form of a spooled item.
+type spooledJSON struct {
+	Table string          `json:"table"`
+	Item  json.RawMessage `json:"item"`
+}
+
+func marshalSpooled(s *spooled) ([]byte, error) {
+	item, err := attributevalue.MarshalMapJSON(s.item)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling item: %w", err)
+	}
+	return json.Marshal(&spooledJSON{Table: s.table, Item: item})
+}
+
+func unmarshalSpooled(data []byte) (*spooled, error) {
+	sj := &spooledJSON{}
+	if err := json.Unmarshal(data, sj); err != nil {
+		return nil, err
+	}
+	item, err := attributevalue.UnmarshalMapJSON(sj.Item)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshaling item: %w", err)
+	}
+	return &spooled{table: sj.Table, item: item}, nil
+}
 
 // Spool writes DynamoDB items to local files and periodically retries putting them in DynamoDB.
+//
+// Flushing is at-least-once so items may be re-put after a crash - see [spool.Spool].
 type Spool struct {
-	client        *dynamodb.Client
-	directory     string
-	size          atomic.Int64
-	flushInterval time.Duration
-
-	ctx    context.Context
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
+	client *dynamodb.Client
+	spool  *spool.Spool[*spooled]
 }
 
+// NewSpool creates a new spool using the given directory and flush interval.
 func NewSpool(client *dynamodb.Client, directory string, flushInterval time.Duration) *Spool {
-	ctx, cancel := context.WithCancel(context.Background())
-
-	return &Spool{
-		client:        client,
-		directory:     directory,
-		flushInterval: flushInterval,
-		ctx:           ctx,
-		cancel:        cancel,
-	}
+	s := &Spool{client: client}
+	s.spool = spool.New(directory, flushInterval, marshalSpooled, unmarshalSpooled, s.flushBatch)
+	return s
 }
 
+// Start starts the spool's background flushing - see [spool.Spool.Start].
 func (s *Spool) Start() error {
-	// ensure directory exists
-	if err := os.MkdirAll(s.directory, 0755); err != nil {
-		return fmt.Errorf("error creating spool directory %s: %w", s.directory, err)
-	}
-
-	// MkdirAll succeeds if directory already exists even if it's not writable, so probe actual writability
-	probe, err := os.CreateTemp(s.directory, ".probe-*")
-	if err != nil {
-		return fmt.Errorf("spool directory %s is not writable: %w", s.directory, err)
-	}
-	probe.Close()
-	os.Remove(probe.Name())
-
-	// enumerate existing files to get current size
-	files, err := s.enumerateFiles()
-	if err != nil {
-		return err
-	}
-	total := 0
-	for _, file := range files {
-		total += file.count
-	}
-	s.size.Store(int64(total))
-
-	s.wg.Add(1)
-
-	go func() {
-		defer s.wg.Done()
-
-		ticker := time.NewTicker(s.flushInterval)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-s.ctx.Done():
-				return
-			case <-ticker.C:
-				if err := s.flush(); err != nil {
-					slog.Error("error flushing spool", "error", err)
-				}
-			}
-		}
-	}()
-
-	return nil
+	return s.spool.Start()
 }
 
+// Stop stops the spool's background flushing - see [spool.Spool.Stop].
 func (s *Spool) Stop() {
-	s.cancel()
-
-	s.wg.Wait()
+	s.spool.Stop()
 }
 
+// Add writes items destined for the given table to a new spool file.
 func (s *Spool) Add(table string, items []map[string]types.AttributeValue) error {
-	path := fmt.Sprintf("%s/%s#%d@%s.jsonl", s.directory, uuids.NewV7(), len(items), table)
-	f, err := os.Create(path)
-	if err != nil {
-		return fmt.Errorf("error creating spool file %s: %w", path, err)
+	batch := make([]*spooled, len(items))
+	for i, item := range items {
+		batch[i] = &spooled{table: table, item: item}
 	}
-	defer f.Close()
-
-	for _, item := range items {
-		marshaled, err := attributevalue.MarshalMapJSON(item)
-		if err != nil {
-			return fmt.Errorf("error marshaling item to JSON for spool file %s: %w", path, err)
-		}
-
-		marshaled = append(marshaled, []byte("\n")...)
-
-		if _, err := f.Write(marshaled); err != nil {
-			return fmt.Errorf("error writing item to spool file %s: %w", path, err)
-		}
-
-		s.size.Add(1)
-	}
-
-	return nil
+	return s.spool.Add(batch)
 }
 
-func (s *Spool) flush() error {
-	ctx := s.ctx
-
-	files, err := s.enumerateFiles()
-	if err != nil {
-		return fmt.Errorf("error enumerating files to flush: %w", err)
-	}
-
-	for _, file := range files {
-		items, err := s.readFile(file.path)
-		if err != nil {
-			return fmt.Errorf("error loading spool file %s: %w", file.path, err)
-		}
-
-		unprocessed, err := batchPutItem(ctx, s.client, file.table, items)
-		if err != nil {
-			slog.Error("error flushing spooled dynamo batch", "error", err, "file", file.path)
-			continue
-		}
-
-		if len(unprocessed) > 0 {
-			// write unprocessed items back to a new spool file
-			if err := s.Add(file.table, unprocessed); err != nil {
-				return fmt.Errorf("error writing unprocessed items back to spool file %s: %w", file.path, err)
-			}
-		}
-
-		if err := os.Remove(file.path); err != nil {
-			return fmt.Errorf("error removing spool file %s: %w", file.path, err)
-		}
-	}
-
-	// refresh size from disk to pick up any manual file changes
-	files, err = s.enumerateFiles()
-	if err != nil {
-		return fmt.Errorf("error enumerating files after flush: %w", err)
-	}
-	total := 0
-	for _, file := range files {
-		total += file.count
-	}
-	s.size.Store(int64(total))
-
-	return nil
-}
-
-func (s *Spool) readFile(path string) ([]map[string]types.AttributeValue, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("error opening spool file %s: %w", path, err)
-	}
-	defer f.Close()
-
-	items := make([]map[string]types.AttributeValue, 0, 25)
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		item, err := attributevalue.UnmarshalMapJSON(scanner.Bytes())
-		if err != nil {
-			return nil, fmt.Errorf("error unmarshaling item from spool file %s: %w", path, err)
-		}
-		items = append(items, item)
-	}
-
-	return items, nil
-}
-
-func (s *Spool) enumerateFiles() ([]spooledFile, error) {
-	files := make([]spooledFile, 0)
-
-	entries, err := os.ReadDir(s.directory)
-	if err != nil {
-		return nil, fmt.Errorf("error listing spool directory %s: %w", s.directory, err)
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			matches := spooledFileRegex.FindStringSubmatch(entry.Name())
-			if len(matches) == 3 {
-				path := fmt.Sprintf("%s/%s", s.directory, entry.Name())
-				count, _ := strconv.Atoi(matches[1])
-				files = append(files, spooledFile{path: path, count: count, table: matches[2]})
-			}
-		}
-	}
-	return files, nil
-}
-
+// Size returns the number of items currently spooled.
 func (s *Spool) Size() int {
-	return int(s.size.Load())
+	return s.spool.Size()
 }
 
+// Delete removes the spool directory and all spooled files.
 func (s *Spool) Delete() error {
-	return os.RemoveAll(s.directory)
+	return s.spool.Delete()
+}
+
+func (s *Spool) flushBatch(ctx context.Context, batch []*spooled) ([]*spooled, error) {
+	// group by table preserving order - though in practice a spool file is written from a single writer batch so all
+	// of its items are for the same table
+	tables := make([]string, 0, 1)
+	byTable := make(map[string][]map[string]types.AttributeValue, 1)
+	for _, sp := range batch {
+		if _, seen := byTable[sp.table]; !seen {
+			tables = append(tables, sp.table)
+		}
+		byTable[sp.table] = append(byTable[sp.table], sp.item)
+	}
+
+	var failed []*spooled
+	for _, table := range tables {
+		unprocessed, err := batchPutItem(ctx, s.client, table, byTable[table])
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range unprocessed {
+			failed = append(failed, &spooled{table: table, item: item})
+		}
+	}
+	return failed, nil
 }

--- a/aws/dynamo/spool_test.go
+++ b/aws/dynamo/spool_test.go
@@ -45,8 +45,8 @@ func TestSpool(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 3, spool.Size())
-	assert.FileExists(t, "./_test_spool/01984174-5600-7000-aded-7d8b151cbd5b#2@TestSpool.jsonl")
-	assert.FileExists(t, "./_test_spool/01984174-59e8-7000-b664-880fc7581c77#1@TestSpool.jsonl")
+	assert.FileExists(t, "./_test_spool/01984174-5600-7000-aded-7d8b151cbd5b#2.jsonl")
+	assert.FileExists(t, "./_test_spool/01984174-59e8-7000-b664-880fc7581c77#1.jsonl")
 
 	spool.Stop()
 

--- a/aws/dynamo/spool_test.go
+++ b/aws/dynamo/spool_test.go
@@ -1,6 +1,7 @@
 package dynamo_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -65,6 +66,48 @@ func TestSpool(t *testing.T) {
 	assert.Equal(t, "Thing 1", obj.Data["name"])
 
 	spool.Stop()
+}
+
+func TestSpoolMixedTableFile(t *testing.T) {
+	ctx := t.Context()
+
+	client, err := dynamo.NewClient(ctx, "http://localstack:4566")
+	require.NoError(t, err)
+
+	defer dyntest.Drop(t, client, "TestSpoolMixed1")
+	defer dyntest.Drop(t, client, "TestSpoolMixed2")
+
+	createTestTable(t, client, "TestSpoolMixed1")
+	createTestTable(t, client, "TestSpoolMixed2")
+
+	// a single spool file can contain items for different tables - can't happen via Add but could be hand crafted,
+	// e.g. by an operator recovering spooled data
+	dir := filepath.Join(t.TempDir(), "spool")
+	require.NoError(t, os.MkdirAll(dir, 0755))
+
+	item1, _ := attributevalue.MarshalMap(&dynamo.Item{Key: dynamo.Key{PK: "P11", SK: "SAA"}, OrgID: 1, Data: map[string]any{"name": "Thing 1"}})
+	item2, _ := attributevalue.MarshalMap(&dynamo.Item{Key: dynamo.Key{PK: "P22", SK: "SBB"}, OrgID: 1, Data: map[string]any{"name": "Thing 2"}})
+	line1, _ := attributevalue.MarshalMapJSON(item1)
+	line2, _ := attributevalue.MarshalMapJSON(item2)
+	content := fmt.Sprintf("{\"table\":\"TestSpoolMixed1\",\"item\":%s}\n{\"table\":\"TestSpoolMixed2\",\"item\":%s}\n", line1, line2)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "mixed#2.jsonl"), []byte(content), 0644))
+
+	spool := dynamo.NewSpool(client, dir, 30*time.Second)
+	require.NoError(t, spool.Start())
+	defer spool.Stop()
+
+	assert.Equal(t, 2, spool.Size())
+
+	require.NoError(t, spool.Flush())
+	assert.Equal(t, 0, spool.Size())
+
+	obj1, err := dynamo.GetItem(ctx, client, "TestSpoolMixed1", dynamo.Key{PK: "P11", SK: "SAA"})
+	require.NoError(t, err)
+	assert.Equal(t, "Thing 1", obj1.Data["name"])
+
+	obj2, err := dynamo.GetItem(ctx, client, "TestSpoolMixed2", dynamo.Key{PK: "P22", SK: "SBB"})
+	require.NoError(t, err)
+	assert.Equal(t, "Thing 2", obj2.Data["name"])
 }
 
 func TestSpoolStartDirectoryErrors(t *testing.T) {

--- a/elastic/spool.go
+++ b/elastic/spool.go
@@ -1,222 +1,24 @@
 package elastic
 
 import (
-	"bufio"
 	"context"
-	"encoding/json"
-	"fmt"
-	"log/slog"
-	"os"
-	"regexp"
-	"strconv"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/elastic/go-elasticsearch/v9"
-	"github.com/nyaruka/gocommon/uuids"
+	"github.com/nyaruka/gocommon/spool"
 )
 
-type spooledFile struct {
-	path  string
-	count int
-}
-
-var spooledFileRegex = regexp.MustCompile(`^[^#]+#(\d+)\.jsonl$`) // <uuid>#<count>.jsonl
-
 // Spool writes Elasticsearch documents to local files and periodically retries indexing them.
-type Spool struct {
-	client        *elasticsearch.TypedClient
-	directory     string
-	size          atomic.Int64
-	flushInterval time.Duration
+//
+// Flushing is at-least-once so documents may be re-indexed after a crash - see [spool.Spool].
+type Spool = spool.Spool[*Document]
 
-	ctx    context.Context
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
-}
-
+// NewSpool creates a new spool using the given directory and flush interval.
 func NewSpool(client *elasticsearch.TypedClient, directory string, flushInterval time.Duration) *Spool {
-	ctx, cancel := context.WithCancel(context.Background())
-
-	return &Spool{
-		client:        client,
-		directory:     directory,
-		flushInterval: flushInterval,
-		ctx:           ctx,
-		cancel:        cancel,
-	}
-}
-
-func (s *Spool) Start() error {
-	// ensure directory exists
-	if err := os.MkdirAll(s.directory, 0755); err != nil {
-		return fmt.Errorf("error creating spool directory %s: %w", s.directory, err)
-	}
-
-	// MkdirAll succeeds if directory already exists even if it's not writable, so probe actual writability
-	probe, err := os.CreateTemp(s.directory, ".probe-*")
-	if err != nil {
-		return fmt.Errorf("spool directory %s is not writable: %w", s.directory, err)
-	}
-	probe.Close()
-	os.Remove(probe.Name())
-
-	// enumerate existing files to get current size
-	files, err := s.enumerateFiles()
-	if err != nil {
-		return err
-	}
-	total := 0
-	for _, file := range files {
-		total += file.count
-	}
-	s.size.Store(int64(total))
-
-	s.wg.Add(1)
-
-	go func() {
-		defer s.wg.Done()
-
-		ticker := time.NewTicker(s.flushInterval)
-		defer ticker.Stop()
-
-		for {
-			select {
-			case <-s.ctx.Done():
-				return
-			case <-ticker.C:
-				if err := s.flush(); err != nil {
-					slog.Error("error flushing spool", "error", err)
-				}
-			}
-		}
-	}()
-
-	return nil
-}
-
-func (s *Spool) Stop() {
-	s.cancel()
-
-	s.wg.Wait()
-}
-
-// Add writes documents to a spool file.
-func (s *Spool) Add(docs []*Document) error {
-	path := fmt.Sprintf("%s/%s#%d.jsonl", s.directory, uuids.NewV7(), len(docs))
-	f, err := os.Create(path)
-	if err != nil {
-		return fmt.Errorf("error creating spool file %s: %w", path, err)
-	}
-	defer f.Close()
-
-	enc := json.NewEncoder(f)
-	for _, doc := range docs {
-		if err := enc.Encode(doc); err != nil {
-			return fmt.Errorf("error writing item to spool file %s: %w", path, err)
-		}
-		s.size.Add(1)
-	}
-
-	return nil
-}
-
-func (s *Spool) flush() error {
-	ctx := s.ctx
-
-	files, err := s.enumerateFiles()
-	if err != nil {
-		return fmt.Errorf("error enumerating files to flush: %w", err)
-	}
-
-	for _, file := range files {
-		docs, err := s.readFile(file.path)
-		if err != nil {
-			return fmt.Errorf("error loading spool file %s: %w", file.path, err)
-		}
-
-		_, unprocessed, err := Bulk(ctx, s.client, docs)
-		if err != nil {
-			slog.Error("error flushing spooled elasticsearch batch", "error", err, "file", file.path)
-			continue
-		}
-
-		if len(unprocessed) > 0 {
-			if err := s.Add(unprocessed); err != nil {
-				return fmt.Errorf("error writing unprocessed items back to spool file %s: %w", file.path, err)
-			}
-		}
-
-		if err := os.Remove(file.path); err != nil {
-			return fmt.Errorf("error removing spool file %s: %w", file.path, err)
-		}
-	}
-
-	// refresh size from disk to pick up any manual file changes
-	files, err = s.enumerateFiles()
-	if err != nil {
-		return fmt.Errorf("error enumerating files after flush: %w", err)
-	}
-	total := 0
-	for _, file := range files {
-		total += file.count
-	}
-	s.size.Store(int64(total))
-
-	return nil
-}
-
-func (s *Spool) readFile(path string) ([]*Document, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("error opening spool file %s: %w", path, err)
-	}
-	defer f.Close()
-
-	var docs []*Document
-
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 1024*1024) // 1MB max line size
-	for scanner.Scan() {
-		var doc Document
-		if err := json.Unmarshal(scanner.Bytes(), &doc); err != nil {
-			return nil, fmt.Errorf("error unmarshalling spool line in %s: %w", path, err)
-		}
-		docs = append(docs, &doc)
-	}
-
-	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error reading spool file %s: %w", path, err)
-	}
-
-	return docs, nil
-}
-
-func (s *Spool) enumerateFiles() ([]spooledFile, error) {
-	files := make([]spooledFile, 0)
-
-	entries, err := os.ReadDir(s.directory)
-	if err != nil {
-		return nil, fmt.Errorf("error listing spool directory %s: %w", s.directory, err)
-	}
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			matches := spooledFileRegex.FindStringSubmatch(entry.Name())
-			if len(matches) == 2 {
-				path := fmt.Sprintf("%s/%s", s.directory, entry.Name())
-				count, _ := strconv.Atoi(matches[1])
-				files = append(files, spooledFile{path: path, count: count})
-			}
-		}
-	}
-	return files, nil
-}
-
-func (s *Spool) Size() int {
-	return int(s.size.Load())
-}
-
-func (s *Spool) Delete() error {
-	return os.RemoveAll(s.directory)
+	return spool.New(directory, flushInterval, spool.MarshalJSON[*Document], spool.UnmarshalJSON[*Document],
+		func(ctx context.Context, batch []*Document) ([]*Document, error) {
+			_, unprocessed, err := Bulk(ctx, client, batch)
+			return unprocessed, err
+		},
+	)
 }

--- a/elastic/spool.go
+++ b/elastic/spool.go
@@ -8,13 +8,9 @@ import (
 	"github.com/nyaruka/gocommon/spool"
 )
 
-// Spool writes Elasticsearch documents to local files and periodically retries indexing them.
-//
-// Flushing is at-least-once so documents may be re-indexed after a crash - see [spool.Spool].
-type Spool = spool.Spool[*Document]
-
-// NewSpool creates a new spool using the given directory and flush interval.
-func NewSpool(client *elasticsearch.TypedClient, directory string, flushInterval time.Duration) *Spool {
+// NewSpool creates a new spool of documents which couldn't be written to Elasticsearch and are periodically retried
+// via [Bulk]. Flushing is at-least-once so documents may be re-indexed after a crash - see [spool.Spool].
+func NewSpool(client *elasticsearch.TypedClient, directory string, flushInterval time.Duration) *spool.Spool[*Document] {
 	return spool.New(directory, flushInterval, spool.MarshalJSON[*Document], spool.UnmarshalJSON[*Document],
 		func(ctx context.Context, batch []*Document) ([]*Document, error) {
 			_, unprocessed, err := Bulk(ctx, client, batch)

--- a/elastic/writer.go
+++ b/elastic/writer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/elastic/go-elasticsearch/v9"
+	"github.com/nyaruka/gocommon/spool"
 	"github.com/nyaruka/gocommon/syncx"
 )
 
@@ -16,7 +17,7 @@ import (
 type Writer struct {
 	client  *elasticsearch.TypedClient
 	batcher *syncx.Batcher[*Document]
-	spool   *Spool
+	spool   *spool.Spool[*Document]
 
 	wg sync.WaitGroup
 
@@ -25,7 +26,7 @@ type Writer struct {
 }
 
 // NewWriter creates a new writer.
-func NewWriter(client *elasticsearch.TypedClient, maxItems int, maxAge time.Duration, bufferSize int, spool *Spool) *Writer {
+func NewWriter(client *elasticsearch.TypedClient, maxItems int, maxAge time.Duration, bufferSize int, spool *spool.Spool[*Document]) *Writer {
 	w := &Writer{
 		client: client,
 		spool:  spool,

--- a/spool/spool.go
+++ b/spool/spool.go
@@ -55,6 +55,9 @@ var errCorrupt = errors.New("corrupt spool file")
 // deduplicated downstream.
 //
 // A file whose content fails to parse is renamed with a .corrupt suffix and thereafter ignored.
+//
+// The directory must be exclusive to a single spool instance: all spools use the same file naming pattern, so a spool
+// can't distinguish its own files from those of another spool sharing the directory and would try to flush them.
 type Spool[T any] struct {
 	directory     string
 	flushInterval time.Duration

--- a/spool/spool.go
+++ b/spool/spool.go
@@ -6,9 +6,11 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"sync"
@@ -42,12 +44,17 @@ var spooledFileRegex = regexp.MustCompile(`^[^#]+#(\d+)\.jsonl$`) // <uuid>#<cou
 
 const maxLineSize = 1024 * 1024 // 1MB
 
+// errCorrupt indicates file content which will never parse, as opposed to a transient read error
+var errCorrupt = errors.New("corrupt spool file")
+
 // Spool writes batches of items to local JSONL files and periodically retries writing them to their primary store
 // using a flush function.
 //
 // Flushing is at-least-once: a crash between a successful flush and removal of the flushed file means that the file's
 // entire batch is replayed on restart. Writes performed by the flush function must therefore be idempotent or
 // deduplicated downstream.
+//
+// A file whose content fails to parse is renamed with a .corrupt suffix and thereafter ignored.
 type Spool[T any] struct {
 	directory     string
 	flushInterval time.Duration
@@ -56,6 +63,7 @@ type Spool[T any] struct {
 	flush         FlushFunc[T]
 
 	size    atomic.Int64
+	sizeMu  sync.Mutex // held whilst making a file visible + incrementing size, and whilst recounting size from disk
 	flushMu sync.Mutex
 
 	ctx    context.Context
@@ -106,6 +114,18 @@ func (s *Spool[T]) Start() error {
 	}
 	s.size.Store(int64(total))
 
+	// warn about files we don't recognize (e.g. written by an older version, or previously quarantined as corrupt)
+	// as they will never be flushed or counted
+	entries, err := os.ReadDir(s.directory)
+	if err != nil {
+		return fmt.Errorf("error listing spool directory %s: %w", s.directory, err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() && !spooledFileRegex.MatchString(entry.Name()) {
+			slog.Warn("ignoring unrecognized file in spool directory", "file", filepath.Join(s.directory, entry.Name()))
+		}
+	}
+
 	s.wg.Add(1)
 
 	go func() {
@@ -139,13 +159,17 @@ func (s *Spool[T]) Stop() {
 // Add writes items to a new spool file. The file is written with a temporary name and renamed into place so that a
 // partially written file is never eligible for flushing.
 func (s *Spool[T]) Add(items []T) error {
-	path := fmt.Sprintf("%s/%s#%d.jsonl", s.directory, uuids.NewV7(), len(items))
+	path := filepath.Join(s.directory, fmt.Sprintf("%s#%d.jsonl", uuids.NewV7(), len(items)))
 	temp := path + ".tmp"
 
 	if err := s.writeFile(temp, items); err != nil {
 		os.Remove(temp)
 		return err
 	}
+
+	// rename and increment under the size lock so a concurrent recount from disk can't miss or double count us
+	s.sizeMu.Lock()
+	defer s.sizeMu.Unlock()
 
 	if err := os.Rename(temp, path); err != nil {
 		os.Remove(temp)
@@ -214,8 +238,17 @@ func (s *Spool[T]) flushAll() error {
 	for _, file := range files {
 		items, err := s.readFile(file.path)
 		if err != nil {
-			// don't let one unreadable file prevent others from being flushed
-			slog.Error("error reading spool file", "error", err, "file", file.path)
+			if errors.Is(err, errCorrupt) {
+				// content will never parse so quarantine the file instead of retrying it forever
+				slog.Error("quarantining corrupt spool file", "error", err, "file", file.path)
+				if err := os.Rename(file.path, file.path+".corrupt"); err != nil {
+					return fmt.Errorf("error quarantining corrupt spool file %s: %w", file.path, err)
+				}
+			} else {
+				// read error may be transient so leave the file for retry, but don't let it prevent
+				// others from being flushed
+				slog.Error("error reading spool file", "error", err, "file", file.path)
+			}
 			continue
 		}
 
@@ -237,7 +270,11 @@ func (s *Spool[T]) flushAll() error {
 		}
 	}
 
-	// refresh size from disk to pick up any manual file changes
+	// refresh size from disk to pick up any manual file changes, under the size lock so we can't clobber or double
+	// count a concurrent Add
+	s.sizeMu.Lock()
+	defer s.sizeMu.Unlock()
+
 	files, err = s.enumerateFiles()
 	if err != nil {
 		return fmt.Errorf("error enumerating files after flush: %w", err)
@@ -265,7 +302,7 @@ func (s *Spool[T]) readFile(path string) ([]T, error) {
 	for scanner.Scan() {
 		item, err := s.unmarshal(scanner.Bytes())
 		if err != nil {
-			return nil, fmt.Errorf("error unmarshaling item from spool file %s: %w", path, err)
+			return nil, fmt.Errorf("%w %s: error unmarshaling item: %w", errCorrupt, path, err)
 		}
 		items = append(items, item)
 	}
@@ -288,7 +325,7 @@ func (s *Spool[T]) enumerateFiles() ([]spooledFile, error) {
 		if !entry.IsDir() {
 			matches := spooledFileRegex.FindStringSubmatch(entry.Name())
 			if len(matches) == 2 {
-				path := fmt.Sprintf("%s/%s", s.directory, entry.Name())
+				path := filepath.Join(s.directory, entry.Name())
 				count, _ := strconv.Atoi(matches[1])
 				files = append(files, spooledFile{path: path, count: count})
 			}

--- a/spool/spool.go
+++ b/spool/spool.go
@@ -1,0 +1,298 @@
+// Package spool provides a generic file-backed spool for items which couldn't be written to their primary store and
+// need to be retried later.
+package spool
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"regexp"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/nyaruka/gocommon/uuids"
+)
+
+// FlushFunc attempts the writing of a batch of previously spooled items to their primary store. It returns any items
+// which couldn't be written and should be respooled, or an error if the batch as a whole couldn't be attempted, in
+// which case it will be retried later in its entirety.
+type FlushFunc[T any] func(ctx context.Context, batch []T) (failed []T, err error)
+
+// MarshalJSON is a marshal function for spools whose items serialize as plain JSON.
+func MarshalJSON[T any](item T) ([]byte, error) { return json.Marshal(item) }
+
+// UnmarshalJSON is an unmarshal function for spools whose items serialize as plain JSON.
+func UnmarshalJSON[T any](data []byte) (T, error) {
+	var item T
+	err := json.Unmarshal(data, &item)
+	return item, err
+}
+
+type spooledFile struct {
+	path  string
+	count int
+}
+
+var spooledFileRegex = regexp.MustCompile(`^[^#]+#(\d+)\.jsonl$`) // <uuid>#<count>.jsonl
+
+const maxLineSize = 1024 * 1024 // 1MB
+
+// Spool writes batches of items to local JSONL files and periodically retries writing them to their primary store
+// using a flush function.
+//
+// Flushing is at-least-once: a crash between a successful flush and removal of the flushed file means that the file's
+// entire batch is replayed on restart. Writes performed by the flush function must therefore be idempotent or
+// deduplicated downstream.
+type Spool[T any] struct {
+	directory     string
+	flushInterval time.Duration
+	marshal       func(T) ([]byte, error)
+	unmarshal     func([]byte) (T, error)
+	flush         FlushFunc[T]
+
+	size    atomic.Int64
+	flushMu sync.Mutex
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// New creates a new spool which stores items in the given directory, marshaling and unmarshaling individual items
+// with the given functions, and retrying batches with the given flush function every flushInterval.
+func New[T any](directory string, flushInterval time.Duration, marshal func(T) ([]byte, error), unmarshal func([]byte) (T, error), flush FlushFunc[T]) *Spool[T] {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &Spool[T]{
+		directory:     directory,
+		flushInterval: flushInterval,
+		marshal:       marshal,
+		unmarshal:     unmarshal,
+		flush:         flush,
+		ctx:           ctx,
+		cancel:        cancel,
+	}
+}
+
+// Start ensures the spool directory exists and is writable, restores the size count from any existing spool files,
+// and starts the background flush loop.
+func (s *Spool[T]) Start() error {
+	// ensure directory exists
+	if err := os.MkdirAll(s.directory, 0755); err != nil {
+		return fmt.Errorf("error creating spool directory %s: %w", s.directory, err)
+	}
+
+	// MkdirAll succeeds if directory already exists even if it's not writable, so probe actual writability
+	probe, err := os.CreateTemp(s.directory, ".probe-*")
+	if err != nil {
+		return fmt.Errorf("spool directory %s is not writable: %w", s.directory, err)
+	}
+	probe.Close()
+	os.Remove(probe.Name())
+
+	// enumerate existing files to get current size
+	files, err := s.enumerateFiles()
+	if err != nil {
+		return err
+	}
+	total := 0
+	for _, file := range files {
+		total += file.count
+	}
+	s.size.Store(int64(total))
+
+	s.wg.Add(1)
+
+	go func() {
+		defer s.wg.Done()
+
+		ticker := time.NewTicker(s.flushInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-s.ctx.Done():
+				return
+			case <-ticker.C:
+				if err := s.flushAll(); err != nil {
+					slog.Error("error flushing spool", "error", err)
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+// Stop stops the background flush loop, waiting for any in progress flush to complete.
+func (s *Spool[T]) Stop() {
+	s.cancel()
+
+	s.wg.Wait()
+}
+
+// Add writes items to a new spool file. The file is written with a temporary name and renamed into place so that a
+// partially written file is never eligible for flushing.
+func (s *Spool[T]) Add(items []T) error {
+	path := fmt.Sprintf("%s/%s#%d.jsonl", s.directory, uuids.NewV7(), len(items))
+	temp := path + ".tmp"
+
+	if err := s.writeFile(temp, items); err != nil {
+		os.Remove(temp)
+		return err
+	}
+
+	if err := os.Rename(temp, path); err != nil {
+		os.Remove(temp)
+		return fmt.Errorf("error renaming spool file %s: %w", temp, err)
+	}
+
+	s.size.Add(int64(len(items)))
+
+	return nil
+}
+
+// Flush performs an immediate flush of all spooled files. Flushing normally happens on the flush interval so this is
+// mostly useful in tests.
+func (s *Spool[T]) Flush() error {
+	return s.flushAll()
+}
+
+// Size returns the number of items currently spooled.
+func (s *Spool[T]) Size() int {
+	return int(s.size.Load())
+}
+
+// Delete removes the spool directory and all spooled files.
+func (s *Spool[T]) Delete() error {
+	return os.RemoveAll(s.directory)
+}
+
+func (s *Spool[T]) writeFile(path string, items []T) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("error creating spool file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	w := bufio.NewWriter(f)
+	for _, item := range items {
+		marshaled, err := s.marshal(item)
+		if err != nil {
+			return fmt.Errorf("error marshaling item for spool file %s: %w", path, err)
+		}
+		if _, err := w.Write(marshaled); err != nil {
+			return fmt.Errorf("error writing item to spool file %s: %w", path, err)
+		}
+		if err := w.WriteByte('\n'); err != nil {
+			return fmt.Errorf("error writing item to spool file %s: %w", path, err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("error writing spool file %s: %w", path, err)
+	}
+
+	return nil
+}
+
+func (s *Spool[T]) flushAll() error {
+	s.flushMu.Lock()
+	defer s.flushMu.Unlock()
+
+	ctx := s.ctx
+
+	files, err := s.enumerateFiles()
+	if err != nil {
+		return fmt.Errorf("error enumerating files to flush: %w", err)
+	}
+
+	for _, file := range files {
+		items, err := s.readFile(file.path)
+		if err != nil {
+			// don't let one unreadable file prevent others from being flushed
+			slog.Error("error reading spool file", "error", err, "file", file.path)
+			continue
+		}
+
+		failed, err := s.flush(ctx, items)
+		if err != nil {
+			slog.Error("error flushing spooled batch", "error", err, "file", file.path)
+			continue
+		}
+
+		if len(failed) > 0 {
+			// write failed items back to a new spool file
+			if err := s.Add(failed); err != nil {
+				return fmt.Errorf("error respooling failed items from spool file %s: %w", file.path, err)
+			}
+		}
+
+		if err := os.Remove(file.path); err != nil {
+			return fmt.Errorf("error removing spool file %s: %w", file.path, err)
+		}
+	}
+
+	// refresh size from disk to pick up any manual file changes
+	files, err = s.enumerateFiles()
+	if err != nil {
+		return fmt.Errorf("error enumerating files after flush: %w", err)
+	}
+	total := 0
+	for _, file := range files {
+		total += file.count
+	}
+	s.size.Store(int64(total))
+
+	return nil
+}
+
+func (s *Spool[T]) readFile(path string) ([]T, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("error opening spool file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var items []T
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, maxLineSize), maxLineSize)
+	for scanner.Scan() {
+		item, err := s.unmarshal(scanner.Bytes())
+		if err != nil {
+			return nil, fmt.Errorf("error unmarshaling item from spool file %s: %w", path, err)
+		}
+		items = append(items, item)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading spool file %s: %w", path, err)
+	}
+
+	return items, nil
+}
+
+func (s *Spool[T]) enumerateFiles() ([]spooledFile, error) {
+	files := make([]spooledFile, 0)
+
+	entries, err := os.ReadDir(s.directory)
+	if err != nil {
+		return nil, fmt.Errorf("error listing spool directory %s: %w", s.directory, err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			matches := spooledFileRegex.FindStringSubmatch(entry.Name())
+			if len(matches) == 2 {
+				path := fmt.Sprintf("%s/%s", s.directory, entry.Name())
+				count, _ := strconv.Atoi(matches[1])
+				files = append(files, spooledFile{path: path, count: count})
+			}
+		}
+	}
+	return files, nil
+}

--- a/spool/spool_test.go
+++ b/spool/spool_test.go
@@ -147,13 +147,15 @@ func TestSpoolCorruptFile(t *testing.T) {
 
 	require.NoError(t, s.Add([]*thing{{Name: "Thing 1", Count: 123}}))
 
-	// a file that can't be read shouldn't prevent other files being flushed
+	// a file that can't be parsed shouldn't prevent other files being flushed, and should be quarantined so that
+	// it isn't retried forever
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "corrupt#1.jsonl"), []byte("{invalid"), 0644))
 
 	require.NoError(t, s.Flush())
 	assert.Equal(t, 1, fl.numBatches())
-	assert.Equal(t, 1, s.Size()) // the corrupt file's claimed count
-	assert.FileExists(t, filepath.Join(dir, "corrupt#1.jsonl"))
+	assert.Equal(t, 0, s.Size())
+	assert.NoFileExists(t, filepath.Join(dir, "corrupt#1.jsonl"))
+	assert.FileExists(t, filepath.Join(dir, "corrupt#1.jsonl.corrupt"))
 }
 
 func TestSpoolAddMarshalError(t *testing.T) {

--- a/spool/spool_test.go
+++ b/spool/spool_test.go
@@ -1,0 +1,206 @@
+package spool_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nyaruka/gocommon/dates"
+	"github.com/nyaruka/gocommon/spool"
+	"github.com/nyaruka/gocommon/uuids"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type thing struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+// flusher is a controllable FlushFunc for testing
+type flusher struct {
+	mu      sync.Mutex
+	batches [][]*thing
+	failing map[string]bool // names of things which should fail to flush
+	err     error           // error to return for whole batches
+}
+
+func (f *flusher) flush(ctx context.Context, batch []*thing) ([]*thing, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.err != nil {
+		return nil, f.err
+	}
+
+	f.batches = append(f.batches, batch)
+
+	var failed []*thing
+	for _, t := range batch {
+		if f.failing[t.Name] {
+			failed = append(failed, t)
+		}
+	}
+	return failed, nil
+}
+
+func (f *flusher) numBatches() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.batches)
+}
+
+func TestSpool(t *testing.T) {
+	uuids.SetGenerator(uuids.NewSeededGenerator(1234, dates.NewSequentialNow(time.Date(2025, 7, 25, 12, 0, 0, 0, time.UTC), time.Second)))
+	defer uuids.SetGenerator(uuids.DefaultGenerator)
+
+	dir := filepath.Join(t.TempDir(), "spool")
+	fl := &flusher{failing: map[string]bool{}}
+
+	s := spool.New(dir, time.Hour, spool.MarshalJSON[*thing], spool.UnmarshalJSON[*thing], fl.flush)
+	require.NoError(t, s.Start())
+	defer s.Stop()
+
+	require.NoError(t, s.Add([]*thing{{Name: "Thing 1", Count: 123}, {Name: "Thing 2", Count: 234}}))
+	require.NoError(t, s.Add([]*thing{{Name: "Thing 3", Count: 345}}))
+
+	assert.Equal(t, 3, s.Size())
+	assert.FileExists(t, filepath.Join(dir, "01984174-5600-7000-aded-7d8b151cbd5b#2.jsonl"))
+	assert.FileExists(t, filepath.Join(dir, "01984174-59e8-7000-b664-880fc7581c77#1.jsonl"))
+
+	data, err := os.ReadFile(filepath.Join(dir, "01984174-5600-7000-aded-7d8b151cbd5b#2.jsonl"))
+	require.NoError(t, err)
+	assert.Equal(t, "{\"name\":\"Thing 1\",\"count\":123}\n{\"name\":\"Thing 2\",\"count\":234}\n", string(data))
+
+	// files whose names don't match the spool pattern are ignored
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.txt"), []byte("!"), 0644))
+
+	// if flushing errors for whole batches, files are kept for retry
+	fl.err = errors.New("boom")
+	require.NoError(t, s.Flush())
+	assert.Equal(t, 3, s.Size())
+	assert.Equal(t, 0, fl.numBatches())
+
+	// if flushing fails for a single item, it's respooled to a new file
+	fl.err = nil
+	fl.failing["Thing 2"] = true
+	require.NoError(t, s.Flush())
+	assert.Equal(t, 2, fl.numBatches())
+	assert.Equal(t, 1, s.Size())
+	assert.NoFileExists(t, filepath.Join(dir, "01984174-5600-7000-aded-7d8b151cbd5b#2.jsonl"))
+	assert.NoFileExists(t, filepath.Join(dir, "01984174-59e8-7000-b664-880fc7581c77#1.jsonl"))
+
+	respooled, err := filepath.Glob(filepath.Join(dir, "*#1.jsonl"))
+	require.NoError(t, err)
+	assert.Len(t, respooled, 1)
+
+	// and flushed on a subsequent attempt
+	fl.failing = map[string]bool{}
+	require.NoError(t, s.Flush())
+	assert.Equal(t, 3, fl.numBatches())
+	assert.Equal(t, 0, s.Size())
+
+	assert.Equal(t, [][]*thing{
+		{{Name: "Thing 1", Count: 123}, {Name: "Thing 2", Count: 234}},
+		{{Name: "Thing 3", Count: 345}},
+		{{Name: "Thing 2", Count: 234}},
+	}, fl.batches)
+}
+
+func TestSpoolRestart(t *testing.T) {
+	uuids.SetGenerator(uuids.NewSeededGenerator(1234, dates.NewSequentialNow(time.Date(2025, 7, 25, 12, 0, 0, 0, time.UTC), time.Second)))
+	defer uuids.SetGenerator(uuids.DefaultGenerator)
+
+	dir := filepath.Join(t.TempDir(), "spool")
+	fl := &flusher{}
+
+	s := spool.New(dir, time.Hour, spool.MarshalJSON[*thing], spool.UnmarshalJSON[*thing], fl.flush)
+	require.NoError(t, s.Start())
+	require.NoError(t, s.Add([]*thing{{Name: "Thing 1", Count: 123}, {Name: "Thing 2", Count: 234}}))
+	require.NoError(t, s.Add([]*thing{{Name: "Thing 3", Count: 345}}))
+	s.Stop()
+
+	// new spool instance picks up size from the existing files and flushes them in the background
+	s = spool.New(dir, 100*time.Millisecond, spool.MarshalJSON[*thing], spool.UnmarshalJSON[*thing], fl.flush)
+	require.NoError(t, s.Start())
+	defer s.Stop()
+
+	assert.Equal(t, 3, s.Size())
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 0, s.Size())
+		assert.Equal(c, 2, fl.numBatches())
+	}, 5*time.Second, 25*time.Millisecond)
+}
+
+func TestSpoolCorruptFile(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "spool")
+	fl := &flusher{}
+
+	s := spool.New(dir, time.Hour, spool.MarshalJSON[*thing], spool.UnmarshalJSON[*thing], fl.flush)
+	require.NoError(t, s.Start())
+	defer s.Stop()
+
+	require.NoError(t, s.Add([]*thing{{Name: "Thing 1", Count: 123}}))
+
+	// a file that can't be read shouldn't prevent other files being flushed
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "corrupt#1.jsonl"), []byte("{invalid"), 0644))
+
+	require.NoError(t, s.Flush())
+	assert.Equal(t, 1, fl.numBatches())
+	assert.Equal(t, 1, s.Size()) // the corrupt file's claimed count
+	assert.FileExists(t, filepath.Join(dir, "corrupt#1.jsonl"))
+}
+
+func TestSpoolAddMarshalError(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "spool")
+
+	marshal := func(t *thing) ([]byte, error) {
+		if t.Name == "bad" {
+			return nil, errors.New("can't marshal")
+		}
+		return spool.MarshalJSON(t)
+	}
+
+	s := spool.New(dir, time.Hour, marshal, spool.UnmarshalJSON[*thing], (&flusher{}).flush)
+	require.NoError(t, s.Start())
+	defer s.Stop()
+
+	// a marshaling failure part way through a batch shouldn't leave a partial file behind
+	err := s.Add([]*thing{{Name: "Thing 1", Count: 123}, {Name: "bad"}})
+	assert.ErrorContains(t, err, "can't marshal")
+	assert.Equal(t, 0, s.Size())
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 0)
+}
+
+func TestSpoolStartDirectoryErrors(t *testing.T) {
+	fl := &flusher{}
+
+	// a file in place of the directory means it can't be created
+	notADir := filepath.Join(t.TempDir(), "spool")
+	require.NoError(t, os.WriteFile(notADir, []byte("!"), 0644))
+
+	s := spool.New(notADir, time.Hour, spool.MarshalJSON[*thing], spool.UnmarshalJSON[*thing], fl.flush)
+	err := s.Start()
+	assert.ErrorContains(t, err, "error creating spool directory")
+
+	// an existing but unwritable directory should fail the writability probe.. but skip if running as
+	// root because then permission bits are ignored
+	if os.Geteuid() == 0 {
+		t.Skip("running as root so can't test unwritable directory")
+	}
+
+	unwritable := filepath.Join(t.TempDir(), "spool")
+	require.NoError(t, os.Mkdir(unwritable, 0555))
+
+	s = spool.New(unwritable, time.Hour, spool.MarshalJSON[*thing], spool.UnmarshalJSON[*thing], fl.flush)
+	err = s.Start()
+	assert.ErrorContains(t, err, "is not writable")
+}


### PR DESCRIPTION
## What

There are currently two near-identical spool implementations in this repo (`dynamo.Spool` and `elastic.Spool` — same JSONL batch files, counts-in-filenames for cheap `Size()`, writability probe on `Start()`, background reflush loop), and courier has a third, older take on the same idea (per-item files, `filepath.Walk`, no `Size()`). This extracts the common layer into a new top-level `spool` package:

- `spool.Spool[T]` — generic file-backed spool with `Start()` (fail-fast writability probe), `Add()`, `Size()`, `Flush()`, `Stop()`, `Delete()` and a configurable flush interval
- serialization is pluggable via marshal/unmarshal funcs; `spool.MarshalJSON`/`spool.UnmarshalJSON` cover the plain-JSON case
- flushing goes through a `FlushFunc[T] func(ctx, batch []T) (failed []T, err error)` so consumers can report partial success — failed items are respooled, and a batch-level error keeps the file for retry as-is
- the `elastic.Spool` type is removed — `elastic.NewSpool` now returns `*spool.Spool[*Document]` directly (same methods and on-disk format; `NewWriter` takes the new type)
- `dynamo.Spool` becomes a thin wrapper keeping its `Add(table, items)` signature, with the table moving from the filename into the line payload

This would let courier's three Postgres spools become typed instantiations (via the JSON helpers plus a flush callback), which would also give them the `Size()` metric they currently lack.

## ⚠️ Breaking / behavioral changes

- **dynamo spool file format changes**: the table name moves from the filename (`<uuid>#<count>@<table>.jsonl`) into each line (`{"table": ..., "item": ...}`). Files written by older versions are **ignored after an upgrade** — not flushed, not deleted — though `Start()` now logs a warning for each unrecognized file so they're discoverable. Deploys should drain spools (they're normally empty) before upgrading, or flush old files manually.
- the `elastic.Spool` type is gone: code referencing it should use `*spool.Spool[*Document]`. `elastic.NewSpool` and the spool's methods are otherwise unchanged; `dynamo.Spool` consumers are unaffected.
- Improvements picked up along the way:
  - spool files are now written to a temp name and renamed into place, so a partially written file (e.g. crash or full disk mid-write) is never flushed
  - a file that fails to read no longer aborts the flush pass — previously one corrupt file permanently blocked flushing of every file after it. Files whose content fails to parse are quarantined with a `.corrupt` suffix instead of being retried (and re-logged) forever; transient read errors still retry
  - fixed a (pre-existing) race between the post-flush `Size()` recount and concurrent `Add()` calls
  - the dynamo spool now gets the 1MB scanner line buffer the elastic one had (it previously risked failing on items over 64KB)
  - a public `Flush()` allowing deterministic tests

## Replay semantics

Flushing is deliberately at-least-once: a crash between a successful flush and file removal replays the whole file's batch on restart. This is now documented on `spool.Spool` — flush writes must be idempotent or deduplicated downstream (dynamo puts are idempotent by key; the same must hold for future consumers).

## Assessment

Honest take on whether the generalization carries its weight:

**For it:** the dynamo and elastic spools were ~220-line copy-pastes differing only in marshal calls and the flush call — the elastic one reduces to a 10-line constructor, and the dynamo one to ~100 lines that are all genuinely dynamo-specific (table-in-payload codec, group-by-table flush). The `FlushFunc` shape was validated by two real consumers with different partial-failure conventions (`batchPutItem` returning unprocessed items, `Bulk` returning them alongside an error), and it maps directly onto a status-update writer that retries failed batch items individually. A plain-JSON consumer needs about the same 10 lines as the elastic one, so a third instantiation is cheap.

**Against it / awkwardness a new consumer would hit:**
- `spool.New` takes five positional arguments; a consumer with plain JSON items writes `spool.New(dir, interval, spool.MarshalJSON[*T], spool.UnmarshalJSON[*T], flushFn)` — workable but verbose. If more options appear (line buffer size, file format version) it should become an options struct.
- there's no first-class per-batch metadata: anything like dynamo's table has to be folded into `T` itself and grouped back out in the flush callback. That was the only real friction point in this migration, and any consumer multiplexing one spool across destinations will hit it too.
- the two failure channels of `FlushFunc` (returned `failed` items vs `err`) have meaningfully different consequences (respool-to-new-file vs keep-file-and-retry) that a consumer must get right; the doc comment carries that weight.

On balance I think it lands as a solid generalization rather than over-engineering — two in-repo duplicates plus a planned third consumer is exactly the threshold where the shared layer pays for itself, and the fixes above (torn files, corrupt-file livelock, scanner buffer) now apply everywhere instead of needing three patches.