### PR TITLE
Add queues package (moved from vkutil)

### DIFF
--- a/queues/export_test.go
+++ b/queues/export_test.go
@@ -1,0 +1,9 @@
+package queues
+
+// SetNewTaskID overrides the task ID generator in tests, or restores the default if fn is nil
+func SetNewTaskID(fn func() TaskID) {
+	if fn == nil {
+		fn = defaultNewTaskID
+	}
+	newTaskID = fn
+}

--- a/queues/fair.go
+++ b/queues/fair.go
@@ -1,0 +1,203 @@
+package queues
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"fmt"
+
+	valkey "github.com/gomodule/redigo/redis"
+)
+
+// Fair implements a fair queue where tasks are distributed evenly across owners.
+//
+// A queue with base key "foo" and owners "owner1" and "owner2" will have the following keys:
+//   - {foo}:queued - set of owners scored by number of queued tasks
+//   - {foo}:active - set of owners scored by number of active tasks
+//   - {foo}:paused - set of paused owners
+//   - {foo}:temp - used internally
+//   - {foo}:o:owner1/0 - e.g. list of tasks for owner1 with priority 0 (low)
+//   - {foo}:o:owner1/1 - e.g. list of tasks for owner1 with priority 1 (high)
+//   - {foo}:o:owner2/0 - e.g. list of tasks for owner2 with priority 0 (low)
+//   - {foo}:o:owner2/1 - e.g. list of tasks for owner2 with priority 1 (high)
+//
+// Note: it would be nice if owner queues could use distict hash tags and so live on different nodes in a cluster, but
+// our push and pop scripts require atomic changes to the queued/active sets and the task lists.
+type Fair struct {
+	keyBase           string
+	maxActivePerOwner int // max number of active tasks per owner
+}
+
+// NewFair creates a new fair queue with the given key base.
+func NewFair(keyBase string, maxActivePerOwner int) *Fair {
+	return &Fair{keyBase: keyBase, maxActivePerOwner: maxActivePerOwner}
+}
+
+//go:embed lua/fair_push.lua
+var luaFairPush string
+var scriptFairPush = valkey.NewScript(4, luaFairPush)
+
+// Push adds the passed in task to our queue for execution
+func (q *Fair) Push(ctx context.Context, vc valkey.Conn, owner OwnerID, priority bool, task []byte) (TaskID, error) {
+	id := newTaskID()
+
+	// prepend UUID to the task
+	var payload bytes.Buffer
+	payload.WriteString(string(id))
+	payload.WriteByte('|')
+	payload.Write(task)
+
+	queueKeys := q.queueKeys(owner)
+
+	_, err := scriptFairPush.Do(vc, q.queuedKey(), q.activeKey(), queueKeys[0], queueKeys[1], owner, priority, payload.Bytes())
+	if err != nil {
+		return "", fmt.Errorf("error pushing task for owner %s: %w", owner, err)
+	}
+	return id, nil
+}
+
+//go:embed lua/fair_pop_owner.lua
+var luaFairPopOwner string
+var scriptFairPopOwner = valkey.NewScript(4, luaFairPopOwner)
+
+//go:embed lua/fair_pop_task.lua
+var luaFairPopTask string
+var scriptFairPopTask = valkey.NewScript(3, luaFairPopTask)
+
+// Pop pops the next task off our queue
+func (q *Fair) Pop(ctx context.Context, vc valkey.Conn) (TaskID, OwnerID, []byte, error) {
+	for {
+		// Select an owner with queued tasks
+		owner, err := valkey.String(scriptFairPopOwner.DoContext(ctx, vc, q.queuedKey(), q.activeKey(), q.pausedKey(), q.tempKey(), q.maxActivePerOwner))
+		if err != nil {
+			return "", "", nil, fmt.Errorf("error selecting task owner: %w", err)
+		}
+		if owner == "" { // None found so no tasks to pop
+			return "", "", nil, nil
+		}
+
+		// Pop a task for the owner
+		queueKeys := q.queueKeys(OwnerID(owner))
+		payload, err := valkey.String(scriptFairPopTask.DoContext(ctx, vc, q.activeKey(), queueKeys[0], queueKeys[1], owner))
+		if err != nil {
+			return "", "", nil, fmt.Errorf("error popping task for owner %s: %w", owner, err)
+		}
+		if payload != "" {
+			id, task, err := parsePayload([]byte(payload))
+			if err != nil {
+				return "", "", nil, fmt.Errorf("error parsing task payload for owner %s: %w", owner, err)
+			}
+
+			return id, OwnerID(owner), task, nil
+		}
+
+		// It's possible that we selected an owner with no tasks, so go back around again
+	}
+}
+
+//go:embed lua/fair_done.lua
+var luaFairDone string
+var scriptFairDone = valkey.NewScript(1, luaFairDone)
+
+// Done marks the passed in task as complete. Callers must call this in order
+// to maintain fair workers across orgs
+func (q *Fair) Done(ctx context.Context, vc valkey.Conn, owner OwnerID) error {
+	_, err := scriptFairDone.Do(vc, q.activeKey(), owner)
+	if err != nil {
+		return fmt.Errorf("error marking task done for owner %s: %w", owner, err)
+	}
+	return nil
+}
+
+// Pause marks the given owner as paused, disabling processing of their tasks
+func (q *Fair) Pause(ctx context.Context, vc valkey.Conn, owner OwnerID) error {
+	_, err := valkey.DoContext(vc, ctx, "SADD", q.pausedKey(), owner)
+	return err
+}
+
+// Resume unmarks the given owner as paused, re-enabling processing of their tasks
+func (q *Fair) Resume(ctx context.Context, vc valkey.Conn, owner OwnerID) error {
+	_, err := valkey.DoContext(vc, ctx, "SREM", q.pausedKey(), owner)
+	return err
+}
+
+// Paused returns the list of owners marked as paused
+func (q *Fair) Paused(ctx context.Context, vc valkey.Conn) ([]OwnerID, error) {
+	strs, err := valkey.Strings(valkey.DoContext(vc, ctx, "SMEMBERS", q.pausedKey()))
+	if err != nil {
+		return nil, err
+	}
+
+	owners := make([]OwnerID, len(strs))
+	for i, str := range strs {
+		owners[i] = OwnerID(str)
+	}
+
+	return owners, nil
+}
+
+// Queued returns the list of owners with queued tasks
+func (q *Fair) Queued(ctx context.Context, vc valkey.Conn) ([]OwnerID, error) {
+	strs, err := valkey.Strings(valkey.DoContext(vc, ctx, "ZRANGE", q.queuedKey(), 0, -1))
+	if err != nil {
+		return nil, err
+	}
+
+	owners := make([]OwnerID, len(strs))
+	for i, str := range strs {
+		owners[i] = OwnerID(str)
+	}
+
+	return owners, nil
+}
+
+// Size returns the number of queued tasks for the given owner
+func (q *Fair) Size(ctx context.Context, vc valkey.Conn, owner OwnerID) (int, error) {
+	queueKeys := q.queueKeys(owner)
+
+	vc.Send("MULTI")
+	vc.Send("LLEN", queueKeys[0])
+	vc.Send("LLEN", queueKeys[1])
+	counts, err := valkey.Ints(valkey.DoContext(vc, ctx, "EXEC"))
+	if err != nil {
+		return 0, err
+	}
+
+	return counts[0] + counts[1], nil
+}
+
+//go:embed lua/fair_dump.lua
+var luaFairDump string
+var scriptFairDump = valkey.NewScript(3, luaFairDump)
+
+func (q *Fair) Dump(ctx context.Context, vc valkey.Conn) ([]byte, error) {
+	dump, err := valkey.Bytes(scriptFairDump.Do(vc, q.queuedKey(), q.activeKey(), q.pausedKey()))
+	if err != nil {
+		return nil, fmt.Errorf("error dumping queue state: %w", err)
+	}
+
+	return dump, nil
+}
+
+func (q *Fair) queuedKey() string {
+	return fmt.Sprintf("{%s}:queued", q.keyBase)
+}
+
+func (q *Fair) activeKey() string {
+	return fmt.Sprintf("{%s}:active", q.keyBase)
+}
+
+func (q *Fair) pausedKey() string {
+	return fmt.Sprintf("{%s}:paused", q.keyBase)
+}
+
+func (q *Fair) tempKey() string {
+	return fmt.Sprintf("{%s}:temp", q.keyBase)
+}
+
+func (q *Fair) queueKeys(owner OwnerID) [2]string {
+	return [2]string{
+		fmt.Sprintf("{%s}:o:%s/0", q.keyBase, owner),
+		fmt.Sprintf("{%s}:o:%s/1", q.keyBase, owner),
+	}
+}

--- a/queues/fair_test.go
+++ b/queues/fair_test.go
@@ -1,0 +1,391 @@
+package queues_test
+
+import (
+	"fmt"
+	"maps"
+	"math/rand/v2"
+	"slices"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	valkey "github.com/gomodule/redigo/redis"
+	"github.com/google/uuid"
+	"github.com/nyaruka/gocommon/queues"
+	"github.com/nyaruka/vkutil/assertvk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFair(t *testing.T) {
+	ctx := t.Context()
+	vp := assertvk.TestDB()
+	vc := vp.Get()
+	defer vc.Close()
+
+	numIDs := 0
+	queues.SetNewTaskID(func() queues.TaskID {
+		numIDs++
+		return queues.TaskID(fmt.Sprintf("01980000-0000-7000-8000-%012d", numIDs))
+	})
+	defer queues.SetNewTaskID(nil)
+
+	defer assertvk.FlushDB()
+
+	q := queues.NewFair("test", 3)
+
+	assertQueued := func(expected map[queues.OwnerID]int) {
+		actualStrings, err := valkey.StringMap(vc.Do("ZRANGE", "{test}:queued", 0, -1, "WITHSCORES"))
+		require.NoError(t, err)
+
+		actual := make(map[queues.OwnerID]int, len(actualStrings))
+		for k, v := range actualStrings {
+			actual[queues.OwnerID(k)], err = strconv.Atoi(v)
+			require.NoError(t, err)
+		}
+
+		assert.Equal(t, expected, actual)
+
+		// checked the .Queued method as well
+		actualOwners, err := q.Queued(ctx, vc)
+		assert.NoError(t, err)
+		assert.ElementsMatch(t, slices.Collect(maps.Keys(expected)), actualOwners)
+	}
+
+	assertActive := func(expected map[queues.OwnerID]int) {
+		actualStrings, err := valkey.StringMap(vc.Do("ZRANGE", "{test}:active", 0, -1, "WITHSCORES"))
+		require.NoError(t, err)
+
+		actual := make(map[queues.OwnerID]int, len(actualStrings))
+		for k, v := range actualStrings {
+			actual[queues.OwnerID(k)], err = strconv.Atoi(v)
+			require.NoError(t, err)
+		}
+
+		assert.Equal(t, expected, actual)
+	}
+
+	assertTasks := func(owner queues.OwnerID, expected0, expected1 []string) {
+		actual0, err := valkey.Strings(vc.Do("LRANGE", "{test}:o:"+owner+"/0", 0, -1))
+		require.NoError(t, err)
+		actual1, err := valkey.Strings(vc.Do("LRANGE", "{test}:o:"+owner+"/1", 0, -1))
+		require.NoError(t, err)
+
+		assert.Equal(t, expected0, actual0, "priority 0 tasks mismatch")
+		assert.Equal(t, expected1, actual1, "priority 1 tasks mismatch")
+
+		// checked .Size() method as well
+		size, err := q.Size(ctx, vc, owner)
+		assert.NoError(t, err)
+		assert.Equal(t, len(expected0)+len(expected1), size)
+	}
+
+	assertDump := func(expected string) {
+		dump, err := q.Dump(ctx, vc)
+		require.NoError(t, err)
+		assert.JSONEq(t, expected, string(dump), "dumped queue state does not match expected")
+	}
+
+	assertQueued(map[queues.OwnerID]int{})
+	assertActive(map[queues.OwnerID]int{})
+	assertTasks("owner1", []string{}, []string{})
+	assertTasks("owner2", []string{}, []string{})
+	assertDump(`{"queued": {}, "active": {}, "paused": {}}`)
+
+	task1UUID := assertPush(t, q, vc, "owner1", false, []byte(`task1`))
+	task2UUID := assertPush(t, q, vc, "owner1", true, []byte(`task2`))
+	task3UUID := assertPush(t, q, vc, "owner2", false, []byte(`task3`))
+	task4UUID := assertPush(t, q, vc, "owner1", false, []byte(`task4`))
+	task5UUID := assertPush(t, q, vc, "owner2", true, []byte(`task5`))
+
+	// nobody processing any tasks so no workers assigned in active set
+	assertQueued(map[queues.OwnerID]int{"owner1": 3, "owner2": 2})
+	assertActive(map[queues.OwnerID]int{})
+	assertTasks("owner1", []string{"01980000-0000-7000-8000-000000000001|task1", "01980000-0000-7000-8000-000000000004|task4"}, []string{"01980000-0000-7000-8000-000000000002|task2"})
+	assertTasks("owner2", []string{"01980000-0000-7000-8000-000000000003|task3"}, []string{"01980000-0000-7000-8000-000000000005|task5"})
+
+	assertPop(t, q, vc, task2UUID, "owner1", "task2") // because it's highest priority for owner 1
+	assertQueued(map[queues.OwnerID]int{"owner1": 2, "owner2": 2})
+	assertActive(map[queues.OwnerID]int{"owner1": 1})
+
+	assertPop(t, q, vc, task5UUID, "owner2", "task5") // because it's highest priority for owner 2
+	assertQueued(map[queues.OwnerID]int{"owner1": 2, "owner2": 1})
+	assertActive(map[queues.OwnerID]int{"owner1": 1, "owner2": 1})
+
+	assertPop(t, q, vc, task1UUID, "owner1", "task1")
+	assertQueued(map[queues.OwnerID]int{"owner1": 1, "owner2": 1})
+	assertActive(map[queues.OwnerID]int{"owner1": 2, "owner2": 1})
+	assertTasks("owner1", []string{"01980000-0000-7000-8000-000000000004|task4"}, []string{})
+	assertTasks("owner2", []string{"01980000-0000-7000-8000-000000000003|task3"}, []string{})
+	assertDump(`{"queued": {"owner1": 1, "owner2": 1}, "active": {"owner1": 2, "owner2": 1}, "paused": {}}`)
+
+	// mark task2 and task1 (owner1) as complete
+	q.Done(ctx, vc, "owner1")
+	q.Done(ctx, vc, "owner1")
+
+	assertQueued(map[queues.OwnerID]int{"owner1": 1, "owner2": 1})
+	assertActive(map[queues.OwnerID]int{"owner2": 1})
+
+	assertPop(t, q, vc, task4UUID, "owner1", "task4")
+	assertPop(t, q, vc, task3UUID, "owner2", "task3")
+	assertTasks("owner1", []string{}, []string{})
+	assertTasks("owner2", []string{}, []string{})
+
+	assertQueued(map[queues.OwnerID]int{})
+	assertActive(map[queues.OwnerID]int{"owner1": 1, "owner2": 2})
+
+	assertPop(t, q, vc, "", "", "") // no more tasks
+	assertTasks("owner1", []string{}, []string{})
+	assertTasks("owner2", []string{}, []string{})
+
+	assertQueued(map[queues.OwnerID]int{})
+	assertActive(map[queues.OwnerID]int{"owner1": 1, "owner2": 2})
+
+	// mark remaining tasks as complete
+	q.Done(ctx, vc, "owner1")
+	q.Done(ctx, vc, "owner2")
+	q.Done(ctx, vc, "owner2")
+
+	assertQueued(map[queues.OwnerID]int{})
+	assertActive(map[queues.OwnerID]int{})
+
+	task6UUID := assertPush(t, q, vc, "owner1", false, []byte(`task6`))
+	task7UUID := assertPush(t, q, vc, "owner1", false, []byte(`task7`))
+	task8UUID := assertPush(t, q, vc, "owner2", false, []byte(`task8`))
+	task9UUID := assertPush(t, q, vc, "owner2", false, []byte(`task9`))
+
+	assertPop(t, q, vc, task6UUID, "owner1", "task6")
+
+	q.Pause(ctx, vc, "owner1")
+	q.Pause(ctx, vc, "owner1") // no-op if already paused
+
+	assertQueued(map[queues.OwnerID]int{"owner1": 1, "owner2": 2})
+	assertActive(map[queues.OwnerID]int{"owner1": 1})
+	assertDump(`{"queued": {"owner1": 1, "owner2": 2}, "active": {"owner1": 1}, "paused": {"owner1": 1}}`)
+
+	paused, err := q.Paused(ctx, vc)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []queues.OwnerID{"owner1"}, paused)
+
+	assertPop(t, q, vc, task8UUID, "owner2", "task8")
+	assertPop(t, q, vc, task9UUID, "owner2", "task9")
+	assertPop(t, q, vc, "", "", "") // no more tasks
+
+	q.Resume(ctx, vc, "owner1")
+	q.Resume(ctx, vc, "owner1") // no-op if already active
+
+	assertQueued(map[queues.OwnerID]int{"owner1": 1})
+	assertActive(map[queues.OwnerID]int{"owner1": 1, "owner2": 2})
+
+	paused, err = q.Paused(ctx, vc)
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, []string{}, paused)
+
+	assertPop(t, q, vc, task7UUID, "owner1", "task7")
+
+	q.Done(ctx, vc, "owner1")
+	q.Done(ctx, vc, "owner1")
+	q.Done(ctx, vc, "owner2")
+	q.Done(ctx, vc, "owner2")
+
+	assertQueued(map[queues.OwnerID]int{})
+	assertActive(map[queues.OwnerID]int{})
+
+	// if we somehow get into a state where an owner is in the queued set but doesn't have queued tasks, pop will retry
+	assertPush(t, q, vc, "owner1", false, []byte("task10"))
+	task11UUID := assertPush(t, q, vc, "owner2", false, []byte("task11"))
+
+	assertQueued(map[queues.OwnerID]int{"owner1": 1, "owner2": 1})
+	assertActive(map[queues.OwnerID]int{})
+
+	assertvk.LLen(t, vc, "{test}:o:owner1/0", 1)
+	_, err = vc.Do("DEL", "{test}:o:owner1/0") // task10 gone
+	assert.NoError(t, err)
+
+	assertPop(t, q, vc, task11UUID, "owner2", "task11")
+	assertPop(t, q, vc, "", "", "")
+
+	assertQueued(map[queues.OwnerID]int{})
+	assertActive(map[queues.OwnerID]int{"owner2": 1})
+
+	// if we somehow call done too many times, we never get negative workers
+	q.Done(ctx, vc, "owner2")
+	q.Done(ctx, vc, "owner2")
+
+	assertActive(map[queues.OwnerID]int{})
+}
+
+func TestTaskPayloads(t *testing.T) {
+	vp := assertvk.TestDB()
+	vc := vp.Get()
+	defer vc.Close()
+
+	defer assertvk.FlushDB()
+
+	q := queues.NewFair("test", 2)
+
+	task1UUID := assertPush(t, q, vc, "owner1", true, []byte(`{"foo": "|"}`))
+	task2UUID := assertPush(t, q, vc, "owner1", true, []byte(`task2`))
+
+	assertPop(t, q, vc, task1UUID, "owner1", `{"foo": "|"}`)
+	assertPop(t, q, vc, task2UUID, "owner1", "task2")
+}
+
+func TestFairMaxActivePerOwner(t *testing.T) {
+	ctx := t.Context()
+	vp := assertvk.TestDB()
+	vc := vp.Get()
+	defer vc.Close()
+
+	defer assertvk.FlushDB()
+
+	q := queues.NewFair("test", 2)
+
+	task1UUID := assertPush(t, q, vc, "owner1", false, []byte(`task1`))
+	task2UUID := assertPush(t, q, vc, "owner1", true, []byte(`task2`))
+	task3UUID := assertPush(t, q, vc, "owner1", false, []byte(`task3`))
+
+	assertPop(t, q, vc, task2UUID, "owner1", "task2")
+	assertPop(t, q, vc, task1UUID, "owner1", "task1")
+	assertPop(t, q, vc, "", "", "") // owner1 has reached max active tasks
+
+	q.Done(ctx, vc, "owner1")
+
+	assertPop(t, q, vc, task3UUID, "owner1", "task3") // now we can pop task3
+}
+
+func TestFairConcurrency(t *testing.T) {
+	ctx := t.Context()
+	vp := assertvk.TestDB()
+	vc := vp.Get()
+	defer vc.Close()
+
+	defer assertvk.FlushDB()
+
+	q := queues.NewFair("test", 5) // one owner can only occupy 5 of the 10 consumers at a time
+
+	type ownerAndTask struct {
+		owner queues.OwnerID
+		task  string
+	}
+
+	numTasks := 10000
+	pushedTasks := make([]*ownerAndTask, 0, numTasks)
+	poppedTasks := make([]*ownerAndTask, 0, numTasks)
+
+	var wg sync.WaitGroup
+	var mutex sync.Mutex
+
+	recordTaskPushed := func(owner queues.OwnerID, task string) {
+		mutex.Lock()
+		defer mutex.Unlock()
+
+		pushedTasks = append(pushedTasks, &ownerAndTask{owner: owner, task: task})
+	}
+
+	recordTaskProcessed := func(owner queues.OwnerID, task string) {
+		mutex.Lock()
+		defer mutex.Unlock()
+
+		poppedTasks = append(poppedTasks, &ownerAndTask{owner: owner, task: task})
+	}
+
+	// Start 5 producers to push tasks each concurrently
+	for i := range 5 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			vc := vp.Get()
+			defer vc.Close()
+
+			for range numTasks / 5 {
+				owner := queues.OwnerID(fmt.Sprintf("owner%d", rand.IntN(5)+1)) // five possible owners (1...5)
+				task := []byte(uuid.Must(uuid.NewV7()).String())
+				_, err := q.Push(ctx, vc, owner, false, task)
+				assert.NoError(t, err, "Producer %d failed to push task for owner %s", i, owner)
+
+				recordTaskPushed(owner, string(task))
+
+				time.Sleep(time.Duration(rand.IntN(5)) * time.Millisecond)
+			}
+		}()
+	}
+
+	// Start 10 consumers to pop tasks concurrently
+	for i := range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			vc := vp.Get()
+			defer vc.Close()
+
+			for {
+				_, owner, task, err := q.Pop(ctx, vc)
+				assert.NoError(t, err, "Consumer %d failed to pop task", i)
+
+				if task != nil {
+					time.Sleep(time.Duration(rand.IntN(5)) * time.Millisecond)
+
+					err = q.Done(ctx, vc, owner)
+					assert.NoError(t, err, "Consumer %d failed to mark task done", i)
+
+					recordTaskProcessed(owner, string(task))
+
+					fmt.Printf("Consumer %d processed task %s for owner %s\n", i, string(task), owner)
+				} else {
+					fmt.Printf("Consumer %d got no task when popping\n", i)
+				}
+				// Check if all tasks have been processed
+				mutex.Lock()
+				allDone := len(poppedTasks) >= numTasks
+				mutex.Unlock()
+
+				if allDone {
+					return
+				} else {
+					time.Sleep(time.Millisecond)
+				}
+			}
+		}()
+	}
+
+	wg.Wait() // Wait for all producers and consumers to complete
+
+	// can't guarantee order of processed tasks, but we can check that all expected tasks were processed
+	assert.ElementsMatch(t, pushedTasks, poppedTasks)
+
+	assertvk.ZGetAll(t, vc, "{test}:queued", map[string]float64{})
+	assertvk.ZGetAll(t, vc, "{test}:active", map[string]float64{})
+
+	for i := range 5 {
+		assertvk.LGetAll(t, vc, fmt.Sprintf("{test}:o:owner%d/0", i+1), []string{})
+		assertvk.LGetAll(t, vc, fmt.Sprintf("{test}:o:owner%d/1", i+1), []string{})
+	}
+}
+
+// assertPush is a helper function that asserts the result of a Push operation
+func assertPush(t *testing.T, q *queues.Fair, vc valkey.Conn, owner queues.OwnerID, priority bool, task []byte) queues.TaskID {
+	ctx := t.Context()
+
+	id, err := q.Push(ctx, vc, owner, priority, task)
+	assert.NoError(t, err)
+	return id
+}
+
+// assertPop is a helper function that asserts the result of a Pop operation
+func assertPop(t *testing.T, q *queues.Fair, vc valkey.Conn, expectedID queues.TaskID, expectedOwner queues.OwnerID, expectedTask string) {
+	ctx := t.Context()
+
+	uuid, owner, task, err := q.Pop(ctx, vc)
+	require.NoError(t, err)
+	if expectedTask != "" {
+		assert.Equal(t, expectedID, uuid)
+		assert.Equal(t, expectedOwner, owner)
+		assert.Equal(t, expectedTask, string(task))
+	} else {
+		assert.Nil(t, task)
+	}
+}

--- a/queues/lua/fair_done.lua
+++ b/queues/lua/fair_done.lua
@@ -1,0 +1,10 @@
+local activeKey = KEYS[1]
+local owner = ARGV[1]
+
+-- decrement our active task count for this owner
+local activeCount = tonumber(redis.call("ZINCRBY", activeKey, -1, owner))
+
+-- remove if zero (or somehow negative)
+if activeCount <= 0 then
+    redis.call("ZREM", activeKey, owner)
+end

--- a/queues/lua/fair_dump.lua
+++ b/queues/lua/fair_dump.lua
@@ -1,0 +1,31 @@
+
+local function dumpZSet(key)
+    local arr = redis.call("ZRANGE", key, 0, -1, "WITHSCORES")
+    local table = {}
+    for i = 1, #arr, 2 do
+        table[arr[i]] = tonumber(arr[i + 1])
+    end
+    return table
+end
+
+-- LUA doesn't have a way to return an empty array as [] and JSON doesn't have sets.. 
+-- so return a set like {"a", "b"} as an object like {"a": 1, "b": 1}
+local function dumpSet(key)
+    local arr = redis.call("SMEMBERS", key)
+    local table = {}
+    for _, v in ipairs(arr) do
+        table[v] = 1
+    end
+    return table
+end
+
+local queuedKey = KEYS[1]
+local activeKey = KEYS[2]
+local pausedKey = KEYS[3]
+
+local result = {}
+result["queued"] = dumpZSet(queuedKey)
+result["active"] = dumpZSet(activeKey)
+result["paused"] = dumpSet(pausedKey) 
+
+return cjson.encode(result)

--- a/queues/lua/fair_pop_owner.lua
+++ b/queues/lua/fair_pop_owner.lua
@@ -1,0 +1,37 @@
+local queuedKey = KEYS[1]
+local activeKey = KEYS[2]
+local pausedKey = KEYS[3]
+local tempKey = KEYS[4]
+local maxActivePerOwner = ARGV[1]
+
+-- create a new set which is union of queued and active owners, with scores from active
+redis.call("ZUNIONSTORE", tempKey, 2, queuedKey, activeKey, "WEIGHTS", 0, 1)
+
+-- intersect with queued owners again to remove any active owners that have no queued tasks
+redis.call("ZINTERSTORE", tempKey, 2, tempKey, queuedKey, "WEIGHTS", 1, 0)
+
+-- substract paused owners from this set
+redis.call("ZDIFFSTORE", tempKey, 2, tempKey, pausedKey)
+
+-- never leave anything without an expiry...
+redis.call("EXPIRE", tempKey, 60)
+
+-- get the owner with the least active tasks
+local result = redis.call("ZRANGEBYSCORE", tempKey, "-inf", "(" .. maxActivePerOwner, "LIMIT", 0, 1)
+
+-- nothing? return nothing
+local owner = result[1]
+if not owner then
+    return ""
+end
+
+-- decrement queued count for this owner
+local queuedCount = tonumber(redis.call("ZINCRBY", queuedKey, -1, owner))
+if queuedCount <= 0 then
+    redis.call("ZREM", queuedKey, owner)
+end
+
+-- increment active count for this owner to prevent races
+redis.call("ZINCRBY", activeKey, 1, owner)
+
+return owner

--- a/queues/lua/fair_pop_task.lua
+++ b/queues/lua/fair_pop_task.lua
@@ -1,0 +1,24 @@
+local activeKey = KEYS[1]
+local queue0Key = KEYS[2]
+local queue1Key = KEYS[3]
+local owner = ARGV[1]
+
+-- pop off our queues (priority first)
+local result = redis.call("LPOP", queue1Key)
+if not result then
+    result = redis.call("LPOP", queue0Key)
+end
+
+-- found a result?
+if result then
+    -- we found a task, active count was already incremented
+    return result
+else
+    -- no result found, decrement active count for this owner
+    local activeCount = tonumber(redis.call("ZINCRBY", activeKey, -1, owner))
+    if activeCount <= 0 then
+        redis.call("ZREM", activeKey, owner)
+    end
+
+    return ""
+end

--- a/queues/lua/fair_push.lua
+++ b/queues/lua/fair_push.lua
@@ -1,0 +1,17 @@
+local queuedKey = KEYS[1]
+local activeKey = KEYS[2]
+local queue0Key = KEYS[3]
+local queue1Key = KEYS[4]
+local owner = ARGV[1]
+local priority = tonumber(ARGV[2])
+local task = ARGV[3]
+
+-- we could just increment queued count but counting the queue sizes makes it self-correcting
+local queuedCount = 0
+if priority == 0 then
+    queuedCount = redis.call("RPUSH", queue0Key, task) + redis.call("LLEN", queue1Key)
+else
+    queuedCount = redis.call("RPUSH", queue1Key, task) + redis.call("LLEN", queue0Key)
+end
+
+redis.call("ZADD", queuedKey, queuedCount, owner)

--- a/queues/task.go
+++ b/queues/task.go
@@ -1,0 +1,40 @@
+package queues
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+
+	"github.com/google/uuid"
+)
+
+// TaskID is the unique identifier for a task in the queue.
+type TaskID string
+
+// OwnerID is the identifier for an owner of tasks in the queue.
+type OwnerID string
+
+var idRegex = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[1-7][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+// newTaskID can be overridden in tests to generate predictable IDs
+var newTaskID func() TaskID = defaultNewTaskID
+
+func defaultNewTaskID() TaskID {
+	return TaskID(uuid.Must(uuid.NewV7()).String())
+}
+
+func parsePayload(raw []byte) (TaskID, []byte, error) {
+	if len(raw) == 0 {
+		return "", nil, fmt.Errorf("empty task payload")
+	}
+
+	parts := bytes.SplitN(raw, []byte{'|'}, 2)
+	if len(parts) != 2 || !idRegex.Match(parts[0]) {
+		return "", nil, fmt.Errorf("invalid task payload: %s", raw)
+	}
+
+	id := TaskID(parts[0])
+	task := parts[1]
+
+	return id, task, nil
+}


### PR DESCRIPTION
Moves the `queues` package (the `Fair` per-owner task queue) from vkutil into this repo, verbatim from vkutil v0.21.0 — the only change is the test file's import path.

Rationale: the fair queue is application-level task queueing (owner fairness caps, priorities, pause/resume, task envelopes) rather than a generic valkey primitive, so it fits better here with the rest of the code shared by its consumers than in vkutil, which stays a library of small generic valkey utilities.

This is step 1 of a larger change:
1. **This PR** — verbatim move, no behavior change (key layout and payload format untouched, so live queues are unaffected).
2. A follow-up PR will rework `Fair` to track in-flight tasks with leases, so that tasks popped by a worker that dies (e.g. force-killed in a container environment) are redelivered instead of lost, and active counts self-heal instead of leaking.
3. Consumers then switch imports and adopt the new API.
4. vkutil drops its `queues` package.

Tests pass locally against valkey 8.1 (`VALKEY_HOST=localhost go test ./queues/`); CI here already runs a valkey service container.