### PR TITLE
Resolve region for virtual-host URLs from SDK config in s3x.NewService

### DIFF
--- a/aws/s3x/service.go
+++ b/aws/s3x/service.go
@@ -3,6 +3,7 @@ package s3x
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -20,9 +21,9 @@ type Service struct {
 	urler  ObjectURLer
 }
 
-// NewService creates a new S3 service, resolving credentials from the standard AWS SDK default chain. The region is
-// still required for virtual-host style object URLs.
-func NewService(ctx context.Context, region, endpoint string, pathStyle bool) (*Service, error) {
+// NewService creates a new S3 service, resolving credentials and region from the standard AWS SDK default chain. A
+// resolvable region is required for virtual-host style object URLs.
+func NewService(ctx context.Context, endpoint string, pathStyle bool) (*Service, error) {
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
 		return nil, err
@@ -32,7 +33,10 @@ func NewService(ctx context.Context, region, endpoint string, pathStyle bool) (*
 	if pathStyle {
 		urler = PathStyleURLer(endpoint)
 	} else {
-		urler = VirtualHostURLer(region)
+		if cfg.Region == "" {
+			return nil, errors.New("unable to resolve AWS region, required for virtual-host style object URLs")
+		}
+		urler = VirtualHostURLer(cfg.Region)
 	}
 
 	client := s3.NewFromConfig(cfg, func(o *s3.Options) {

--- a/aws/s3x/service_test.go
+++ b/aws/s3x/service_test.go
@@ -1,6 +1,7 @@
 package s3x_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -13,7 +14,7 @@ import (
 func TestService(t *testing.T) {
 	ctx := t.Context()
 
-	svc, err := s3x.NewService(ctx, "us-east-1", "http://localstack:4566", true)
+	svc, err := s3x.NewService(ctx, "http://localstack:4566", true)
 	assert.NoError(t, err)
 
 	err = svc.Test(ctx, "gocommon-tests")
@@ -74,7 +75,18 @@ func TestService(t *testing.T) {
 	err = svc.Test(ctx, "gocommon-tests")
 	assert.Error(t, err)
 
-	aws, err := s3x.NewService(ctx, "us-east-1", "https://s3.amazonaws.com", false)
+	// ensure no region is resolvable from the host environment
+	t.Setenv("AWS_REGION", "")
+	t.Setenv("AWS_DEFAULT_REGION", "")
+	t.Setenv("AWS_CONFIG_FILE", os.DevNull)
+
+	// virtual-host style URLs require a resolvable region
+	_, err = s3x.NewService(ctx, "https://s3.amazonaws.com", false)
+	assert.EqualError(t, err, "unable to resolve AWS region, required for virtual-host style object URLs")
+
+	t.Setenv("AWS_REGION", "us-east-1")
+
+	aws, err := s3x.NewService(ctx, "https://s3.amazonaws.com", false)
 	assert.NoError(t, err)
 	assert.Equal(t, "https://gocommon-tests.s3.us-east-1.amazonaws.com/1/hello+world.txt", aws.ObjectURL("gocommon-tests", "1/hello world.txt"))
 }


### PR DESCRIPTION
`s3x.NewService` took a `region` param that was only used to build virtual-host style object URLs — the S3 client itself already gets its region from the SDK default chain via the `LoadDefaultConfig` call inside `NewService`. That forced callers using virtual-host URLs to load the AWS config themselves just to fish out the region and pass it back in, duplicating the config load.

Now `NewService(ctx, endpoint, pathStyle)` uses `cfg.Region` from the config it already loads, and returns an error if no region is resolvable when virtual-host style URLs are requested. Path-style setups (e.g. localstack, minio) often have no region configured and don't need one, so they're exempt from the check.

This makes s3x consistent with `dynamo.NewClient` and `cwatch.NewService`, neither of which take a region. Callers just drop the region argument — this module is internal-use, so no compatibility shim.

Tests cover the new empty-region error; the test blanks `AWS_REGION`/`AWS_DEFAULT_REGION`/`AWS_CONFIG_FILE` first so it also passes on machines with a real AWS config present.