### PR TITLE
Expose resolved region as field on s3x.Service

### DIFF
--- a/aws/s3x/service.go
+++ b/aws/s3x/service.go
@@ -18,7 +18,12 @@ import (
 // Service is simple abstraction layer to work with a S3-compatible storage service
 type Service struct {
 	Client *s3.Client
-	urler  ObjectURLer
+
+	// Region is the AWS region resolved from the SDK default chain, and is what object URLs are qualified with when
+	// using virtual-host style URLs. It can be empty when using path-style URLs.
+	Region string
+
+	urler ObjectURLer
 }
 
 // NewService creates a new S3 service, resolving credentials and region from the standard AWS SDK default chain. A
@@ -47,7 +52,7 @@ func NewService(ctx context.Context, endpoint string, pathStyle bool) (*Service,
 		o.UsePathStyle = pathStyle // urls as endpoint/bucket/key instead of bucket.endpoint/key
 	})
 
-	return &Service{Client: client, urler: urler}, nil
+	return &Service{Client: client, Region: cfg.Region, urler: urler}, nil
 }
 
 // ObjectURL returns the publicly accessible URL for the given object

--- a/aws/s3x/service_test.go
+++ b/aws/s3x/service_test.go
@@ -84,9 +84,15 @@ func TestService(t *testing.T) {
 	_, err = s3x.NewService(ctx, "https://s3.amazonaws.com", false)
 	assert.EqualError(t, err, "unable to resolve AWS region, required for virtual-host style object URLs")
 
+	// but path-style URLs don't
+	noRegion, err := s3x.NewService(ctx, "http://localstack:4566", true)
+	assert.NoError(t, err)
+	assert.Equal(t, "", noRegion.Region)
+
 	t.Setenv("AWS_REGION", "us-east-1")
 
 	aws, err := s3x.NewService(ctx, "https://s3.amazonaws.com", false)
 	assert.NoError(t, err)
+	assert.Equal(t, "us-east-1", aws.Region)
 	assert.Equal(t, "https://gocommon-tests.s3.us-east-1.amazonaws.com/1/hello+world.txt", aws.ObjectURL("gocommon-tests", "1/hello world.txt"))
 }


### PR DESCRIPTION
Since #225, `s3x.NewService` resolves the AWS region from the SDK default chain itself, but callers that need to reason about region-qualified virtual-host object URLs (e.g. courier normalizing media URL hostnames) had to load the SDK config again just to get the same region.

This exposes the resolved region as a `Region` field on `Service` so callers can drop that duplicate resolution. It can be empty when using path-style URLs, where no region is required — callers should handle that case.