### PR TITLE
Migrate from math/rand to math/rand/v2

### DIFF
--- a/aws/dynamo/spool_test.go
+++ b/aws/dynamo/spool_test.go
@@ -46,8 +46,8 @@ func TestSpool(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 3, spool.Size())
-	assert.FileExists(t, "./_test_spool/01984174-5600-7000-aded-7d8b151cbd5b#2.jsonl")
-	assert.FileExists(t, "./_test_spool/01984174-59e8-7000-b664-880fc7581c77#1.jsonl")
+	assert.FileExists(t, "./_test_spool/01984174-5600-7000-8e0f-6b2abe4360d8#2.jsonl")
+	assert.FileExists(t, "./_test_spool/01984174-59e8-7000-9a98-cfcce3019710#1.jsonl")
 
 	spool.Stop()
 

--- a/elastic/spool_test.go
+++ b/elastic/spool_test.go
@@ -38,8 +38,8 @@ func TestSpool(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 3, spool.Size())
-	assert.FileExists(t, "./_test_spool/01984174-5600-7000-aded-7d8b151cbd5b#2.jsonl")
-	assert.FileExists(t, "./_test_spool/01984174-59e8-7000-b664-880fc7581c77#1.jsonl")
+	assert.FileExists(t, "./_test_spool/01984174-5600-7000-8e0f-6b2abe4360d8#2.jsonl")
+	assert.FileExists(t, "./_test_spool/01984174-59e8-7000-9a98-cfcce3019710#1.jsonl")
 
 	spool.Stop()
 

--- a/httpx/retries_test.go
+++ b/httpx/retries_test.go
@@ -44,18 +44,18 @@ func TestNewExponentialRetries(t *testing.T) {
 	// test backoffs with 5% jitter
 	retries.Jitter = 0.05
 
-	assert.Equal(t, time.Duration(1964211898), retries.Backoff(0))
-	assert.Equal(t, time.Duration(3970345144), retries.Backoff(1))
-	assert.Equal(t, time.Duration(8142741864), retries.Backoff(2))
-	assert.Equal(t, time.Duration(15884061444), retries.Backoff(3))
+	assert.Equal(t, time.Duration(2047085134), retries.Backoff(0))
+	assert.Equal(t, time.Duration(3908410473), retries.Backoff(1))
+	assert.Equal(t, time.Duration(8011635928), retries.Backoff(2))
+	assert.Equal(t, time.Duration(16390662899), retries.Backoff(3))
 
 	// test backoffs with 100% jitter
 	retries.Jitter = 1.0
 
-	assert.Equal(t, time.Duration(1280781995), retries.Backoff(0))
-	assert.Equal(t, time.Duration(5877181643), retries.Backoff(1))
-	assert.Equal(t, time.Duration(8587700930), retries.Backoff(2))
-	assert.Equal(t, time.Duration(9120513163), retries.Backoff(3))
+	assert.Equal(t, time.Duration(1682256946), retries.Backoff(0))
+	assert.Equal(t, time.Duration(2654297682), retries.Backoff(1))
+	assert.Equal(t, time.Duration(9503023613), retries.Backoff(2))
+	assert.Equal(t, time.Duration(9126733867), retries.Backoff(3))
 }
 
 func TestParseRetryAfter(t *testing.T) {

--- a/random/rand.go
+++ b/random/rand.go
@@ -1,21 +1,20 @@
 package random
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"sync"
-	"time"
 
 	"github.com/shopspring/decimal"
 )
 
 // DefaultGenerator is the default generator for calls to Rand()
-var DefaultGenerator = rand.New(rand.NewSource(time.Now().UnixNano()))
+var DefaultGenerator = rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
 var currentGenerator = DefaultGenerator
 var lock sync.Mutex
 
 // NewSeededGenerator creates a new seeded generator
 func NewSeededGenerator(seed int64) *rand.Rand {
-	return rand.New(rand.NewSource(seed))
+	return rand.New(rand.NewPCG(uint64(seed), uint64(seed)))
 }
 
 // SetGenerator sets the rand used by Rand()
@@ -27,7 +26,7 @@ func SetGenerator(rnd *rand.Rand) {
 func IntN(n int) int {
 	lock.Lock()
 	defer lock.Unlock()
-	return currentGenerator.Intn(n)
+	return currentGenerator.IntN(n)
 }
 
 // Float64 returns, as a float64, a pseudo-random number in the half-open interval [0.0,1.0).

--- a/random/rand_test.go
+++ b/random/rand_test.go
@@ -14,15 +14,15 @@ func TestRand(t *testing.T) {
 	defer random.SetGenerator(random.DefaultGenerator)
 	random.SetGenerator(random.NewSeededGenerator(1234))
 
-	assert.Equal(t, 2, random.IntN(10))
-	assert.Equal(t, 5, random.IntN(10))
-	assert.Equal(t, 9, random.IntN(10))
-	assert.Equal(t, decimal.RequireFromString("0.8989115230327291"), random.Decimal())
-	assert.Equal(t, decimal.RequireFromString("0.6087185537746531"), random.Decimal())
-	assert.Equal(t, decimal.RequireFromString("0.3023554328904116"), random.Decimal())
+	assert.Equal(t, 0, random.IntN(10))
+	assert.Equal(t, 8, random.IntN(10))
+	assert.Equal(t, 4, random.IntN(10))
+	assert.Equal(t, decimal.RequireFromString("0.7189806938374759"), random.Decimal())
+	assert.Equal(t, decimal.RequireFromString("0.824272697040096"), random.Decimal())
+	assert.Equal(t, decimal.RequireFromString("0.10545532824596571"), random.Decimal())
 
-	assert.Equal(t, "Ej22bFMALM", random.String(10, []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")))
-	assert.Equal(t, "a!!aa!!a!a", random.String(10, []rune("a!z")))
+	assert.Equal(t, "lJ4ZfHEr25", random.String(10, []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/")))
+	assert.Equal(t, "zzzaaz!aaz", random.String(10, []rune("a!z")))
 }
 
 func TestRandConcurrency(t *testing.T) {

--- a/spools/spools_test.go
+++ b/spools/spools_test.go
@@ -69,10 +69,10 @@ func TestSpool(t *testing.T) {
 	require.NoError(t, s.Add([]*thing{{Name: "Thing 3", Count: 345}}))
 
 	assert.Equal(t, 3, s.Size())
-	assert.FileExists(t, filepath.Join(dir, "01984174-5600-7000-aded-7d8b151cbd5b#2.jsonl"))
-	assert.FileExists(t, filepath.Join(dir, "01984174-59e8-7000-b664-880fc7581c77#1.jsonl"))
+	assert.FileExists(t, filepath.Join(dir, "01984174-5600-7000-8e0f-6b2abe4360d8#2.jsonl"))
+	assert.FileExists(t, filepath.Join(dir, "01984174-59e8-7000-9a98-cfcce3019710#1.jsonl"))
 
-	data, err := os.ReadFile(filepath.Join(dir, "01984174-5600-7000-aded-7d8b151cbd5b#2.jsonl"))
+	data, err := os.ReadFile(filepath.Join(dir, "01984174-5600-7000-8e0f-6b2abe4360d8#2.jsonl"))
 	require.NoError(t, err)
 	assert.Equal(t, "{\"name\":\"Thing 1\",\"count\":123}\n{\"name\":\"Thing 2\",\"count\":234}\n", string(data))
 
@@ -91,8 +91,8 @@ func TestSpool(t *testing.T) {
 	require.NoError(t, s.Flush())
 	assert.Equal(t, 2, fl.numBatches())
 	assert.Equal(t, 1, s.Size())
-	assert.NoFileExists(t, filepath.Join(dir, "01984174-5600-7000-aded-7d8b151cbd5b#2.jsonl"))
-	assert.NoFileExists(t, filepath.Join(dir, "01984174-59e8-7000-b664-880fc7581c77#1.jsonl"))
+	assert.NoFileExists(t, filepath.Join(dir, "01984174-5600-7000-8e0f-6b2abe4360d8#2.jsonl"))
+	assert.NoFileExists(t, filepath.Join(dir, "01984174-59e8-7000-9a98-cfcce3019710#1.jsonl"))
 
 	respooled, err := filepath.Glob(filepath.Join(dir, "*#1.jsonl"))
 	require.NoError(t, err)

--- a/syncx/mutex_test.go
+++ b/syncx/mutex_test.go
@@ -1,7 +1,7 @@
 package syncx_test
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"sort"
 	"sync"
 	"testing"
@@ -65,7 +65,7 @@ func TestHashMutex(t *testing.T) {
 	randString := func(n int) string {
 		b := make([]rune, n)
 		for i := range b {
-			b[i] = letters[rand.Intn(len(letters))]
+			b[i] = letters[rand.IntN(len(letters))]
 		}
 		return string(b)
 	}

--- a/uuids/uuid.go
+++ b/uuids/uuid.go
@@ -3,7 +3,7 @@ package uuids
 import (
 	"encoding/hex"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strings"
 	"time"
 
@@ -53,16 +53,31 @@ func SetGenerator(generator Generator) {
 	currentGenerator = generator
 }
 
-// generates a seedable random v4 UUID using math/rand
-type seededGenerator struct {
+// adapts a math/rand/v2 generator to io.Reader for use with uuid.NewRandomFromReader
+type randReader struct {
 	rnd *rand.Rand
+}
+
+func (r randReader) Read(p []byte) (int, error) {
+	for i := 0; i < len(p); i += 8 {
+		v := r.rnd.Uint64()
+		for j := 0; j < 8 && i+j < len(p); j++ {
+			p[i+j] = byte(v >> (8 * j))
+		}
+	}
+	return len(p), nil
+}
+
+// generates a seedable random v4 UUID using math/rand/v2
+type seededGenerator struct {
+	rnd randReader
 	now dates.NowFunc
 }
 
 // NewSeededGenerator creates a new UUID generator that uses the given seed for the random component and the time source
 // for the time component (only applies to v7)
 func NewSeededGenerator(seed int64, now dates.NowFunc) Generator {
-	return &seededGenerator{rnd: random.NewSeededGenerator(seed), now: now}
+	return &seededGenerator{rnd: randReader{random.NewSeededGenerator(seed)}, now: now}
 }
 
 // NextV4 returns the next v4 UUID

--- a/uuids/uuid_test.go
+++ b/uuids/uuid_test.go
@@ -36,7 +36,7 @@ func TestNewV7(t *testing.T) {
 
 func TestV7Time(t *testing.T) {
 	// test with a known v7 UUID from the seeded generator (2024-08-01 17:29:30 UTC)
-	tm, err := uuids.V7Time("01910efd-5890-71e2-bd38-d266ec8d3716")
+	tm, err := uuids.V7Time("01910efd-5890-71e2-98c7-1f0d5859f77e")
 	assert.NoError(t, err)
 	assert.Equal(t, time.Date(2024, 8, 1, 17, 29, 30, 0, time.UTC), tm.Truncate(time.Second))
 
@@ -72,14 +72,14 @@ func TestSeededGenerator(t *testing.T) {
 	assert.Equal(t, 7, uuids.Version(string(uuid2)))
 	assert.Equal(t, 4, uuids.Version(string(uuid3)))
 
-	assert.Equal(t, uuids.UUID(`d2f852ec-7b4e-457f-ae7f-f8b243c49ff5`), uuid1)
-	assert.Equal(t, uuids.UUID(`01910efd-5890-71e2-bd38-d266ec8d3716`), uuid2)
-	assert.Equal(t, uuids.UUID(`8720f157-ca1c-432f-9c0b-2014ddc77094`), uuid3)
+	assert.Equal(t, uuids.UUID(`1b2083ab-a0cb-48da-924e-9de1a11831b3`), uuid1)
+	assert.Equal(t, uuids.UUID(`01910efd-5890-71e2-98c7-1f0d5859f77e`), uuid2)
+	assert.Equal(t, uuids.UUID(`b26fcae1-abb6-49f8-95cf-9fca95f1c30a`), uuid3)
 
 	uuids.SetGenerator(uuids.NewSeededGenerator(123456, dates.NewSequentialNow(time.Date(2024, 7, 32, 17, 29, 30, 123456, time.UTC), time.Second)))
 
 	// should get same sequence again for same seed
-	assert.Equal(t, uuids.UUID(`d2f852ec-7b4e-457f-ae7f-f8b243c49ff5`), uuids.NewV4())
-	assert.Equal(t, uuids.UUID(`01910efd-5890-71e2-bd38-d266ec8d3716`), uuids.NewV7())
-	assert.Equal(t, uuids.UUID(`8720f157-ca1c-432f-9c0b-2014ddc77094`), uuids.NewV4())
+	assert.Equal(t, uuids.UUID(`1b2083ab-a0cb-48da-924e-9de1a11831b3`), uuids.NewV4())
+	assert.Equal(t, uuids.UUID(`01910efd-5890-71e2-98c7-1f0d5859f77e`), uuids.NewV7())
+	assert.Equal(t, uuids.UUID(`b26fcae1-abb6-49f8-95cf-9fca95f1c30a`), uuids.NewV4())
 }


### PR DESCRIPTION
Switches `random` and `uuids` (and the one remaining test usage in `syncx`) from `math/rand` to `math/rand/v2`, removing all v1 imports from the module.

## Changes

- `random`: seeded generators now use `rand.NewPCG`; the default generator is seeded from v2's auto-seeded top-level source instead of `time.Now()`. `Intn` → `IntN`.
- `uuids`: v2's `*rand.Rand` no longer implements `io.Reader`, so the seeded generator wraps it in a small adapter for `uuid.NewRandomFromReader`.

## Notes for reviewers

- PCG produces different sequences than v1's source, so hardcoded seeded expectations (random values, UUIDs, spool filenames) in the `random`, `uuids`, `httpx`, `spools`, `elastic` and `aws/dynamo` tests have been regenerated.
- Downstream projects that assert seeded UUIDs/random values in tests will see different sequences when they upgrade to a release containing this.