### PR TITLE
Harden input handling against panics and unbounded allocation

### DIFF
--- a/dates/i18n_test.go
+++ b/dates/i18n_test.go
@@ -46,3 +46,13 @@ func TestGetTranslation(t *testing.T) {
 		assert.Equal(t, tc.am, trans.AmPm[0], "AM mismatch for locale %s", tc.locale)
 	}
 }
+
+func TestGetTranslationMalformedLocale(t *testing.T) {
+	// a malformed locale must not panic, it just falls back to a usable translation
+	for _, loc := range []i18n.Locale{"!!!", "xxx", "x", "абв", "zzz-ZZ"} {
+		assert.NotPanics(t, func() {
+			trans := dates.GetTranslation(loc)
+			require.NotNil(t, trans, "trans unexpectedly nil for locale '%s'", loc)
+		}, "GetTranslation panicked for locale '%s'", loc)
+	}
+}

--- a/gsm7/gsm7.go
+++ b/gsm7/gsm7.go
@@ -1,6 +1,9 @@
 package gsm7
 
-import "bytes"
+import (
+	"bytes"
+	"strings"
+)
 
 // base gsm7 characters in our normal table
 var baseGSM7 = map[rune]byte{
@@ -272,10 +275,14 @@ func Encode(str string) []byte {
 
 // Decode decodes the passed in bytes as GSM7 encodings. Each byte is expected to
 // be a single 7 bit GSM7 character.
-func Decode(gsm7 []byte) (str string) {
+func Decode(gsm7 []byte) string {
 	var escaped bool
 	var found bool
 	var r rune
+
+	// each byte decodes to at most one rune, so len(gsm7) is a safe upper bound to preallocate
+	var sb strings.Builder
+	sb.Grow(len(gsm7))
 
 	for _, b := range gsm7 {
 		if b > max {
@@ -292,9 +299,9 @@ func Decode(gsm7 []byte) (str string) {
 		} else {
 			r = gsm7ToBase[b]
 		}
-		str += string(r)
+		sb.WriteRune(r)
 	}
-	return str
+	return sb.String()
 }
 
 // Segments calculates the number of SMS segments it will take to send the passed in text.

--- a/gsm7/gsm7_test.go
+++ b/gsm7/gsm7_test.go
@@ -1,8 +1,10 @@
 package gsm7_test
 
 import (
+	"bytes"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nyaruka/gocommon/gsm7"
 
@@ -28,6 +30,22 @@ func TestEncodeDecode(t *testing.T) {
 	assert.Equal(t, "?toobig", gsm7.Decode([]byte("\x81toobig")))
 
 	assert.Equal(t, []byte("hi!\x20\x3F"), gsm7.Encode("hi! ☺"))
+}
+
+// decoding a large payload must stay linear - a quadratic implementation would blow up on memory/time here
+func TestDecodeLargeInput(t *testing.T) {
+	input := bytes.Repeat([]byte{0x61}, 1<<20) // 1MB of 'a'
+
+	done := make(chan string, 1)
+	go func() { done <- gsm7.Decode(input) }()
+
+	select {
+	case out := <-done:
+		assert.Equal(t, len(input), len(out))
+		assert.Equal(t, strings.Repeat("a", len(input)), out)
+	case <-time.After(5 * time.Second):
+		t.Fatal("gsm7.Decode of 1MB did not complete within 5s - likely quadratic")
+	}
 }
 
 func TestValid(t *testing.T) {

--- a/i18n/locale.go
+++ b/i18n/locale.go
@@ -41,7 +41,12 @@ func (l Locale) Split() (Language, Country) {
 }
 
 func (l Locale) tag() language.Tag {
-	return language.MustParse(string(l))
+	// don't panic on a malformed locale, just treat it as undetermined so matching falls back to a default
+	t, err := language.Parse(string(l))
+	if err != nil {
+		return language.Und
+	}
+	return t
 }
 
 var NilLocale = Locale("")
@@ -62,7 +67,12 @@ type BCP47Matcher struct {
 func NewBCP47Matcher(codes ...string) *BCP47Matcher {
 	tags := make([]language.Tag, len(codes))
 	for i := range codes {
-		tags[i] = language.MustParse(codes[i])
+		// keep the tags slice aligned with codes; a malformed code becomes undetermined rather than panicking
+		t, err := language.Parse(codes[i])
+		if err != nil {
+			t = language.Und
+		}
+		tags[i] = t
 	}
 	return &BCP47Matcher{codes: codes, matcher: language.NewMatcher(tags)}
 }

--- a/i18n/locale_test.go
+++ b/i18n/locale_test.go
@@ -61,3 +61,17 @@ func TestBCP47Matcher(t *testing.T) {
 		assert.Equal(t, tc.best, best, "locale mismatch for preferred=%v available=%s", tc.preferred, tc.available)
 	}
 }
+
+func TestBCP47MatcherMalformed(t *testing.T) {
+	// malformed preferred locales must not panic, they just fall back to a default match
+	assert.NotPanics(t, func() {
+		m := i18n.NewBCP47Matcher("en-US", "es-US")
+		assert.Equal(t, "en-US", m.ForLocales("!!!", "xxx", "абв"))
+	})
+
+	// malformed available codes must not panic either
+	assert.NotPanics(t, func() {
+		m := i18n.NewBCP47Matcher("!!!", "en-US")
+		m.ForLocales("eng-US")
+	})
+}

--- a/stringsx/truncate.go
+++ b/stringsx/truncate.go
@@ -11,9 +11,16 @@ func TruncateEllipsis(s string, limit int) string {
 }
 
 func truncate(s string, limit int, ending string) string {
+	if limit < 0 {
+		limit = 0
+	}
 	runes := []rune(s)
 	if len(runes) <= limit {
 		return s
+	}
+	// not enough room to fit the ending, so just hard-truncate to the limit
+	if limit <= len(ending) {
+		return string(runes[:limit])
 	}
 	return string(runes[:limit-len(ending)]) + ending
 }

--- a/stringsx/truncate_test.go
+++ b/stringsx/truncate_test.go
@@ -15,6 +15,14 @@ func TestTruncateEllipsis(t *testing.T) {
 	assert.Equal(t, "你喜欢我当然喜欢的电", stringsx.TruncateEllipsis("你喜欢我当然喜欢的电", 100))
 	assert.Equal(t, "你喜欢我当然喜欢的电", stringsx.TruncateEllipsis("你喜欢我当然喜欢的电", 10))
 	assert.Equal(t, "你喜欢我...", stringsx.TruncateEllipsis("你喜欢我当然喜欢的电", 7))
+
+	// limits smaller than the ellipsis must not panic - just hard-truncate to the limit
+	assert.Equal(t, "123", stringsx.TruncateEllipsis("1234567890", 3))
+	assert.Equal(t, "12", stringsx.TruncateEllipsis("1234567890", 2))
+	assert.Equal(t, "1", stringsx.TruncateEllipsis("1234567890", 1))
+	assert.Equal(t, "", stringsx.TruncateEllipsis("1234567890", 0))
+	assert.Equal(t, "", stringsx.TruncateEllipsis("1234567890", -1))
+	assert.Equal(t, "你", stringsx.TruncateEllipsis("你喜欢我当然喜欢的电", 1))
 }
 
 func TestTruncate(t *testing.T) {
@@ -25,4 +33,8 @@ func TestTruncate(t *testing.T) {
 	assert.Equal(t, "你喜欢我当然喜欢的电", stringsx.Truncate("你喜欢我当然喜欢的电", 100))
 	assert.Equal(t, "你喜欢我当然喜欢的电", stringsx.Truncate("你喜欢我当然喜欢的电", 10))
 	assert.Equal(t, "你喜欢我当然喜", stringsx.Truncate("你喜欢我当然喜欢的电", 7))
+
+	// zero and negative limits must not panic
+	assert.Equal(t, "", stringsx.Truncate("1234567890", 0))
+	assert.Equal(t, "", stringsx.Truncate("1234567890", -1))
 }


### PR DESCRIPTION
Audit prompted by two security advisories against a phone-number parsing library — one where crafted input caused a slice-out-of-bounds panic, another where input drove a large memory allocation. This looks for and fixes the same two bug classes in this library, plus a related panic found along the way.

## Changes

**`stringsx.Truncate` / `TruncateEllipsis` — slice-out-of-bounds panic**
When the limit was smaller than the ellipsis length (or negative), `runes[:limit-len(ending)]` computed a negative bound and panicked. Negative limits are now clamped to 0, and when there's no room for the ending the string is hard-truncated to the limit.

**`gsm7.Decode` — unbounded memory/CPU on large input**
The result was built with `str += string(r)` in a loop, which is O(n²). Decoding a 1 MB inbound payload took ~23s and churned hundreds of GB of allocation — a cheap DoS on untrusted SMS data. It now accumulates into a pre-grown `strings.Builder`, making decoding linear.

**`i18n` locale matching — panic on malformed locale**
`Locale.tag()` and `NewBCP47Matcher` used `language.MustParse`, so a malformed locale reaching `dates.Format` → `GetTranslation` panicked. They now use `language.Parse` and fall back to the undetermined tag, degrading to a default match instead of crashing.

## Tests

- `stringsx`: added boundary limits (0–3, negative) for both ASCII and multi-byte strings.
- `gsm7`: `TestDecodeLargeInput` decodes 1 MB with a 5s watchdog that would time out against the old quadratic implementation.
- `i18n` and `dates`: assert no panic on malformed locale inputs.

Note: the phone-number parsing here delegates to the `phonenumbers/v2` dependency (the actual subject of the upstream advisories), which is already up to date in this repo, so no change was needed there.