### PR TITLE
Add request/response size tracking to httpx traces and logs

### DIFF
--- a/httpx/logs.go
+++ b/httpx/logs.go
@@ -8,15 +8,23 @@ import (
 	"github.com/nyaruka/gocommon/stringsx"
 )
 
+// TraceSizes are the true sizes in bytes of a request and response, recorded because the traces themselves are
+// trimmed for logging.
+type TraceSizes struct {
+	Request  int `json:"request"`
+	Response int `json:"response"`
+}
+
 // LogWithoutTime is a single HTTP trace that can be serialized/deserialized to/from JSON. Note that this struct has no
 // time component because it's intended to be embedded in something that does.
 type LogWithoutTime struct {
-	URL        string `json:"url" validate:"required"`
-	StatusCode int    `json:"status_code,omitempty"`
-	Request    string `json:"request" validate:"required"`
-	Response   string `json:"response,omitempty"`
-	ElapsedMS  int    `json:"elapsed_ms"`
-	Retries    int    `json:"retries"`
+	URL        string     `json:"url" validate:"required"`
+	StatusCode int        `json:"status_code,omitempty"`
+	Request    string     `json:"request" validate:"required"`
+	Response   string     `json:"response,omitempty"`
+	ElapsedMS  int        `json:"elapsed_ms"`
+	Retries    int        `json:"retries"`
+	Sizes      TraceSizes `json:"sizes"`
 }
 
 // NewLogWithoutTime creates a new log
@@ -43,6 +51,7 @@ func NewLogWithoutTime(trace *Trace, trimURLTo, trimTracesTo int, redact strings
 		Response:   stringsx.TruncateEllipsis(response, trimTracesTo),
 		ElapsedMS:  int((trace.EndTime.Sub(trace.StartTime)) / time.Millisecond),
 		Retries:    trace.Retries,
+		Sizes:      TraceSizes{Request: trace.RequestSize(), Response: trace.ResponseSize()},
 	}
 }
 

--- a/httpx/logs_test.go
+++ b/httpx/logs_test.go
@@ -49,6 +49,15 @@ func TestLogs(t *testing.T) {
 	assert.Equal(t, "GET /code/987654321/long-url/rwhrehreh/erhether/yreyrreyeyreu...", log1.Request)
 	assert.Equal(t, "HTTP/1.0 400 Bad Request\r\nContent-Length: 97\r\n\r\nlong response...", log1.Response)
 
+	// but the true sizes are recorded
+	assert.Equal(t, httpx.TraceSizes{Request: 288, Response: 145}, log1.Sizes)
+
+	// if a response body was discarded (e.g. read limit exceeded), the server declared Content-Length is
+	// used to record the true response size
+	trace1.ResponseBody = nil
+	log1 = httpx.NewLog(trace1, 32, 64, nil)
+	assert.Equal(t, httpx.TraceSizes{Request: 288, Response: 145}, log1.Sizes)
+
 	// create a request with a code we need to redact in the URL and in the header
 	req2, err := httpx.NewRequest(ctx, "GET", "http://temba.io/code/987654321/", nil, map[string]string{"X-Code": "987654321"})
 	require.NoError(t, err)

--- a/httpx/traces.go
+++ b/httpx/traces.go
@@ -37,6 +37,23 @@ func (t *Trace) String() string {
 	return b.String()
 }
 
+// RequestSize returns the size in bytes of the request (headers and body).
+func (t *Trace) RequestSize() int {
+	return len(t.RequestTrace)
+}
+
+// ResponseSize returns the size in bytes of the response (headers and body). If the body was discarded by the caller
+// (e.g. because reading it exceeded a limit set with WithReadLimit and failed with ErrResponseSize) then the server
+// declared Content-Length, if any, is used as the best available record of its true size. Chunked or decompressed
+// responses declare no length and so will under-report.
+func (t *Trace) ResponseSize() int {
+	bodySize := len(t.ResponseBody)
+	if t.ResponseBody == nil && t.Response != nil && t.Response.ContentLength > 0 {
+		bodySize = int(t.Response.ContentLength)
+	}
+	return len(t.ResponseTrace) + bodySize
+}
+
 // SanitizedRequest returns a valid UTF-8 string version of the request, substituting the body with a placeholder
 // if it isn't valid UTF-8. It also strips any NULL characters as not all external dependencies can handle those.
 func (t *Trace) SanitizedRequest(placeholder string) string {

--- a/httpx/traces_test.go
+++ b/httpx/traces_test.go
@@ -122,6 +122,40 @@ func TestTracesTransportConcurrent(t *testing.T) {
 	assert.Len(t, tt.Traces(), 20)
 }
 
+func TestTraceSizes(t *testing.T) {
+	ctx := context.Background()
+
+	tt := httpx.WithTraces(httpx.WithMocks(http.DefaultTransport, map[string][]*httpx.MockResponse{
+		"https://temba.io": {
+			httpx.NewMockResponse(200, nil, []byte(`{"ok": true}`)),
+		},
+	}))
+
+	request, err := httpx.NewRequest(ctx, "POST", "https://temba.io", bytes.NewReader([]byte(`{"foo": "bar"}`)), nil)
+	require.NoError(t, err)
+
+	resp, err := tt.RoundTrip(request)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	trace := tt.Traces()[0]
+	assert.Equal(t, len(trace.RequestTrace), trace.RequestSize())
+	assert.Equal(t, len(trace.ResponseTrace)+12, trace.ResponseSize())
+
+	// if the body was discarded, the server declared Content-Length is used in its place
+	trace.ResponseBody = nil
+	assert.Equal(t, len(trace.ResponseTrace)+12, trace.ResponseSize())
+
+	// unless there isn't one, e.g. a chunked response
+	trace.Response.ContentLength = -1
+	assert.Equal(t, len(trace.ResponseTrace), trace.ResponseSize())
+
+	// a connection error leaves no response at all
+	trace.Response = nil
+	trace.ResponseTrace = nil
+	assert.Equal(t, 0, trace.ResponseSize())
+}
+
 func TestNonUTF8Request(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
Adds `Trace.RequestSize()` and `Trace.ResponseSize()` and records these on `LogWithoutTime` as a new `sizes` field.

The `request`/`response` text on logs is trimmed to the caller's limits, so the true sizes need recording separately. If a response body was discarded (e.g. it exceeded a read limit set with `WithReadLimit`) the server declared `Content-Length` is used as the best available record of its true size — chunked/decompressed responses declare no length and will under-report.

No `validate:"required"` on the new field so logs serialized before it existed read back as zeros.