### PR TITLE
Limit URN path length such that identities always fit in typical storage

### DIFF
--- a/urns/urns.go
+++ b/urns/urns.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	maxPathLength    = 255
-	maxDisplayLength = 255
+	maxIdentityLength = 255
+	maxPathLength     = 255
+	maxDisplayLength  = 255
 )
 
 // IsValidScheme checks whether the provided scheme is valid
@@ -105,6 +106,11 @@ func (u URN) Validate() error {
 
 	if len(path) > maxPathLength {
 		return fmt.Errorf("path component too long")
+	}
+
+	// identity (scheme:path) is what most systems store so has to be bounded as well
+	if len(scheme)+1+len(path) > maxIdentityLength {
+		return fmt.Errorf("identity too long")
 	}
 
 	s := schemeByPrefix[scheme]

--- a/urns/urns.go
+++ b/urns/urns.go
@@ -7,9 +7,10 @@ import (
 )
 
 const (
-	maxIdentityLength = 255
-	maxPathLength     = 255
-	maxDisplayLength  = 255
+	// paths are limited such that any scheme:path identity fits comfortably in the 255 char columns
+	// that systems typically use to store them
+	maxPathLength    = 200
+	maxDisplayLength = 255
 )
 
 // IsValidScheme checks whether the provided scheme is valid
@@ -104,14 +105,9 @@ func (u URN) Validate() error {
 		return fmt.Errorf("unknown URN scheme")
 	}
 
-	if len(path) > maxPathLength {
+	// measured in its escaped form since that's what is stored
+	if len(escape(path)) > maxPathLength {
 		return fmt.Errorf("path component too long")
-	}
-
-	// identity (scheme:path) is what most systems store so has to be bounded as well - measured in its escaped
-	// form since that's what is stored
-	if len(u.Identity()) > maxIdentityLength {
-		return fmt.Errorf("identity too long")
 	}
 
 	s := schemeByPrefix[scheme]

--- a/urns/urns.go
+++ b/urns/urns.go
@@ -108,8 +108,9 @@ func (u URN) Validate() error {
 		return fmt.Errorf("path component too long")
 	}
 
-	// identity (scheme:path) is what most systems store so has to be bounded as well
-	if len(scheme)+1+len(path) > maxIdentityLength {
+	// identity (scheme:path) is what most systems store so has to be bounded as well - measured in its escaped
+	// form since that's what is stored
+	if len(u.Identity()) > maxIdentityLength {
 		return fmt.Errorf("identity too long")
 	}
 

--- a/urns/urns_test.go
+++ b/urns/urns_test.go
@@ -272,11 +272,11 @@ func TestValidate(t *testing.T) {
 
 		{"slack:U0123ABCDEF", ""},
 
-		// paths can be up to 255 chars but the whole identity (scheme:path) is also limited to 255
-		{urns.URN("ext:" + strings.Repeat("x", 251)), ""},
-		{urns.URN("ext:" + strings.Repeat("x", 252)), "identity too long"},
-		{urns.URN("ext:" + strings.Repeat("x", 256)), "path component too long"},
-		{urns.URN("ext:" + strings.Repeat("%", 100)), "identity too long"}, // path chars that escape count in their escaped form
+		// paths can be up to 200 chars, measured in their escaped form
+		{urns.URN("ext:" + strings.Repeat("x", 200)), ""},
+		{urns.URN("ext:" + strings.Repeat("x", 201)), "path component too long"},
+		{urns.URN("ext:" + strings.Repeat("%", 66)), ""},                        // escapes to 198 chars
+		{urns.URN("ext:" + strings.Repeat("%", 67)), "path component too long"}, // escapes to 201 chars
 
 		{"webchat:aA3456789012345678901234", ""},
 		{"webchat:aA3456789012345678901234:bob@nyaruka.com", ""},

--- a/urns/urns_test.go
+++ b/urns/urns_test.go
@@ -276,6 +276,7 @@ func TestValidate(t *testing.T) {
 		{urns.URN("ext:" + strings.Repeat("x", 251)), ""},
 		{urns.URN("ext:" + strings.Repeat("x", 252)), "identity too long"},
 		{urns.URN("ext:" + strings.Repeat("x", 256)), "path component too long"},
+		{urns.URN("ext:" + strings.Repeat("%", 100)), "identity too long"}, // path chars that escape count in their escaped form
 
 		{"webchat:aA3456789012345678901234", ""},
 		{"webchat:aA3456789012345678901234:bob@nyaruka.com", ""},

--- a/urns/urns_test.go
+++ b/urns/urns_test.go
@@ -272,6 +272,11 @@ func TestValidate(t *testing.T) {
 
 		{"slack:U0123ABCDEF", ""},
 
+		// paths can be up to 255 chars but the whole identity (scheme:path) is also limited to 255
+		{urns.URN("ext:" + strings.Repeat("x", 251)), ""},
+		{urns.URN("ext:" + strings.Repeat("x", 252)), "identity too long"},
+		{urns.URN("ext:" + strings.Repeat("x", 256)), "path component too long"},
+
 		{"webchat:aA3456789012345678901234", ""},
 		{"webchat:aA3456789012345678901234:bob@nyaruka.com", ""},
 		{"webchat:1234567890123456789", "invalid path component"},


### PR DESCRIPTION
## Problem

`URN.Validate` bounded the path and display components at 255 chars, but not the identity (`scheme:path`) — which is what most systems actually store, typically in a 255 char column. A URN with a path near the limit (e.g. `ext:` + 255 chars) passed validation but was too long to save, surfacing as database errors far from the source (e.g. failing an entire contact import batch, see nyaruka/mailroom#1158).

## Changes

* `maxPathLength` reduced from 255 to 200, so that `scheme:path` always fits in a 255 char column for any scheme (longest scheme is 10 chars) — with generous headroom over real-world path lengths.
* The path is measured in its escaped form (`%`, `#` and `?` escape to 3 chars) since that's what gets stored, so a single check bounds the stored identity by construction and no separate identity check is needed.
* Boundary test cases at 200/201 path chars, plain and escaping.