### PR TITLE
Make phone parsing idempotent

### DIFF
--- a/urns/phone.go
+++ b/urns/phone.go
@@ -94,9 +94,10 @@ func parsePossibleNumber(input string, country i18n.Country, allowShort, allowSe
 	return "", ErrNotNumber
 }
 
-// formats a number as E164, re-parsing the result until it's stable, because numbers with leading zeros in their
-// national significant number can format to an E164 form that re-parses differently, e.g. +82011290 re-parses with
-// the 0 stripped as a national prefix, giving +8211290
+// formats a number as E164, re-parsing the result to check it's stable (i.e. re-parses to itself), because numbers
+// with leading zeros in their national significant number can format to an E164 form that re-parses differently,
+// e.g. +82011290 re-parses with the 0 stripped as a national prefix, giving +8211290. Numbers that don't stabilize
+// within a few attempts are rejected.
 func formatE164(parsed *phonenumbers.PhoneNumber) (string, bool) {
 	e164 := phonenumbers.Format(parsed, phonenumbers.E164)
 

--- a/urns/phone.go
+++ b/urns/phone.go
@@ -55,7 +55,9 @@ func parsePossibleNumber(input string, country i18n.Country, allowShort, allowSe
 	// check to see if we have a possible number
 	if err == nil {
 		if phonenumbers.IsPossibleNumberWithReason(parsed) == phonenumbers.IS_POSSIBLE {
-			return phonenumbers.Format(parsed, phonenumbers.E164), nil
+			if e164, ok := formatE164(parsed); ok {
+				return e164, nil
+			}
 		}
 	}
 
@@ -64,7 +66,9 @@ func parsePossibleNumber(input string, country i18n.Country, allowShort, allowSe
 		parsedWithPlus, err := phonenumbers.Parse("+"+input, string(country))
 		if err == nil {
 			if phonenumbers.IsPossibleNumberWithReason(parsedWithPlus) == phonenumbers.IS_POSSIBLE {
-				return phonenumbers.Format(parsedWithPlus, phonenumbers.E164), nil
+				if e164, ok := formatE164(parsedWithPlus); ok {
+					return e164, nil
+				}
 			}
 		}
 	}
@@ -88,6 +92,26 @@ func parsePossibleNumber(input string, country i18n.Country, allowShort, allowSe
 	}
 
 	return "", ErrNotNumber
+}
+
+// formats a number as E164, re-parsing the result until it's stable, because numbers with leading zeros in their
+// national significant number can format to an E164 form that re-parses differently, e.g. +82011290 re-parses with
+// the 0 stripped as a national prefix, giving +8211290
+func formatE164(parsed *phonenumbers.PhoneNumber) (string, bool) {
+	e164 := phonenumbers.Format(parsed, phonenumbers.E164)
+
+	for range 3 {
+		reparsed, err := phonenumbers.Parse(e164, "")
+		if err != nil || phonenumbers.IsPossibleNumberWithReason(reparsed) != phonenumbers.IS_POSSIBLE {
+			return "", false
+		}
+		reformatted := phonenumbers.Format(reparsed, phonenumbers.E164)
+		if reformatted == e164 {
+			return e164, true
+		}
+		e164 = reformatted
+	}
+	return "", false
 }
 
 // ToLocalPhone converts a phone URN to a local phone number.. without any leading zeros. Kinda weird but used by

--- a/urns/phone_test.go
+++ b/urns/phone_test.go
@@ -96,6 +96,13 @@ func TestParseNumber(t *testing.T) {
 		{"PRIZES", "RW", false, false, "", "not a possible number"},
 		{"PRIZES", "RW", true, false, "", "not a possible number"},
 		{"PRIZES", "RW", true, true, "prizes", ""},
+
+		// numbers with leading zeros in their national significant number parse to their stable form, i.e. the form
+		// that re-parses to itself, so that parsing is idempotent
+		{"+82011290", "", false, false, "+8211290", ""},
+		{"880003147120", "US", false, false, "+8803147120", ""},
+		{"087043843093", "KR", false, false, "+8243843093", ""},
+		{"090883344803", "BR", false, false, "+55883344803", ""},
 	}
 
 	for i, tc := range testCases {
@@ -108,6 +115,12 @@ func TestParseNumber(t *testing.T) {
 		} else {
 			if assert.NoError(t, err, "%d: unexpected error for %s, %s", i, tc.input, tc.country) {
 				assert.Equal(t, tc.expectedNum, num, "%d: URN mismatch for %s, %s", i, tc.input, tc.country)
+
+				// check parsing is idempotent
+				num2, err := urns.ParseNumber(num, tc.country, tc.allowShort, tc.allowSenderID)
+				if assert.NoError(t, err, "%d: unexpected error re-parsing %s", i, num) {
+					assert.Equal(t, num, num2, "%d: re-parse mismatch for %s", i, num)
+				}
 			}
 		}
 	}

--- a/urns/urns.go
+++ b/urns/urns.go
@@ -80,17 +80,20 @@ func (u URN) ToParts() (string, string, string, string) {
 
 // Normalize normalizes the URN into it's canonical form and should be performed before URN comparisons
 func (u URN) Normalize() URN {
-	scheme, path, query, display := u.ToParts()
-	s := schemeByPrefix[scheme]
+	parsed, err := parseURN(string(u))
+	if err != nil {
+		return u // structurally invalid URNs are left as is
+	}
 
-	path = strings.TrimSpace(path)
-	display = strings.TrimSpace(display)
+	path := strings.TrimSpace(parsed.path)
+	display := strings.TrimSpace(parsed.fragment)
 
+	s := schemeByPrefix[parsed.scheme]
 	if s != nil && s.Normalize != nil {
 		path = s.Normalize(path)
 	}
 
-	return newFromParts(scheme, path, query, display)
+	return newFromParts(parsed.scheme, path, parsed.query, display)
 }
 
 // Validate returns whether this URN is considered valid

--- a/urns/urns_test.go
+++ b/urns/urns_test.go
@@ -119,6 +119,16 @@ func TestNormalize(t *testing.T) {
 		{"tel:mtn", "tel:mtn"},
 		{"tel:+12345678901234567890", "tel:+12345678901234567890"},
 
+		// numbers with leading zeros in their national significant number re-parse to their stable form
+		{"tel:+82011290", "tel:+8211290"},
+
+		// structurally invalid URNs are left as they are
+		{"tel:", "tel:"},
+		{"xxxx", "xxxx"},
+
+		// even if trimming produces a structurally invalid URN, re-normalizing leaves it as is
+		{"tel: ", "tel:"},
+
 		// twitter handles remove @
 		{"twitter: @jimmyJO", "twitter:jimmyjo"},
 		{"twitterid:12345#jimmyJO", "twitterid:12345#jimmyJO"},


### PR DESCRIPTION
Follow up to #85 — normalization was made idempotent for the cases known at the time, but fuzzing `ParseNumber`/`URN.Normalize` (~5M random inputs) surfaced a remaining family of flapping values plus one structural edge case.

## Phone numbers with leading zeros in their national significant number

When libphonenumber keeps a leading zero in the national significant number, it formats to an E164 form that re-parses differently — the zero is stripped as a national prefix on the second pass:

- `ParseNumber("+82011290", "")` → `+82011290`, but parsing that again → `+8211290`
- `ParseNumber("880003147120", "US")` → `+88003147120` → `+8803147120`

`parsePossibleNumber` now formats via a new `formatE164` helper which re-parses the result until it's stable, rejecting numbers that don't converge to a possible number. The flapping inputs above now return the stable form on the first parse.

This is upstream libphonenumber behavior, not a quirk of the Go port — the official Java demo produces identical parse states for these numbers, and the maintainers have [confirmed the lenient leading-zero handling is intentional](https://groups.google.com/g/libphonenumber-discuss/c/_6JAx1gAn1o): the parser corrects input rather than validating it, stripping at most one trunk zero per parse. Their recommended handling for strict consumers is to parse, format, and compare against the input — which is what `formatE164` does. The instability only affects possible-but-invalid numbers, which we deliberately accept, so the idempotency guarantee has to live here.

## Normalizing structurally invalid URNs

`URN.Normalize()` on an unparseable URN went through the `ToParts` fallback that treats the whole string as a path, so each call prepended a colon: `tel:` → `:tel:` → `::tel:` → … Such URNs are now returned unchanged (they still fail `Validate`).

## Tests

Added the fuzz-derived cases to `TestParseNumber` and `TestNormalize`, plus a blanket re-parse assertion in the `TestParseNumber` loop mirroring the existing re-normalize check in `TestNormalize`.

## Behavior changes to note

- Inputs that previously parsed to an unstable form now parse directly to the stable one, so identities stored in the unstable form will normalize differently than what's stored — same caveat as any normalization tightening.
- `Normalize` on a structurally invalid URN now returns it verbatim instead of a mangled `:xxxx`-style string with an empty scheme — callers should not have relied on the old output, but it is a contract change.