### PR TITLE
Fix flaky spool/writer tests and a data race in syncx.Batcher

### DIFF
--- a/aws/dynamo/ops_test.go
+++ b/aws/dynamo/ops_test.go
@@ -46,40 +46,40 @@ func TestPutAndGet(t *testing.T) {
 	client, err := dynamo.NewClient(ctx, "http://localstack:4566")
 	assert.NoError(t, err)
 
-	defer dyntest.Drop(t, client, "TestThings")
+	defer dyntest.Drop(t, client, "TestPutAndGet")
 
-	err = dynamo.Test(ctx, client, "TestThings")
+	err = dynamo.Test(ctx, client, "TestPutAndGet")
 	assert.Error(t, err)
 
-	createTestTable(t, client, "TestThings")
+	createTestTable(t, client, "TestPutAndGet")
 
-	err = dynamo.Test(ctx, client, "TestThings")
+	err = dynamo.Test(ctx, client, "TestPutAndGet")
 	assert.NoError(t, err)
 
 	thing1 := &dynamo.Item{Key: dynamo.Key{PK: "P11", SK: "SAA"}, OrgID: 1, Data: map[string]any{"name": "Thing 1"}}
 	thing2 := &dynamo.Item{Key: dynamo.Key{PK: "P22", SK: "SBB"}, OrgID: 1, Data: map[string]any{"name": "Thing 2"}}
 
-	err = dynamo.PutItem(ctx, client, "TestThings", thing1)
+	err = dynamo.PutItem(ctx, client, "TestPutAndGet", thing1)
 	assert.NoError(t, err)
-	err = dynamo.PutItem(ctx, client, "TestThings", thing2)
+	err = dynamo.PutItem(ctx, client, "TestPutAndGet", thing2)
 	assert.NoError(t, err)
 
-	dyntest.AssertCount(t, client, "TestThings", 2)
+	dyntest.AssertCount(t, client, "TestPutAndGet", 2)
 
-	obj, err := dynamo.GetItem(ctx, client, "TestThings", dynamo.Key{PK: "P11", SK: "SAA"})
+	obj, err := dynamo.GetItem(ctx, client, "TestPutAndGet", dynamo.Key{PK: "P11", SK: "SAA"})
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]any{"name": "Thing 1"}, obj.Data)
 
 	// try to get a non-existent item
-	obj, err = dynamo.GetItem(ctx, client, "TestThings", dynamo.Key{PK: "P77", SK: "SAA"})
+	obj, err = dynamo.GetItem(ctx, client, "TestPutAndGet", dynamo.Key{PK: "P77", SK: "SAA"})
 	assert.NoError(t, err)
 	assert.Nil(t, obj)
 
-	unprocessed, err := dynamo.BatchPutItem(ctx, client, "TestThings", []*dynamo.Item{})
+	unprocessed, err := dynamo.BatchPutItem(ctx, client, "TestPutAndGet", []*dynamo.Item{})
 	assert.NoError(t, err)
 	assert.Equal(t, []*dynamo.Item{}, unprocessed)
 
-	unprocessed, err = dynamo.BatchPutItem(ctx, client, "TestThings", []*dynamo.Item{
+	unprocessed, err = dynamo.BatchPutItem(ctx, client, "TestPutAndGet", []*dynamo.Item{
 		{Key: dynamo.Key{PK: "BATCH1", SK: "S1"}, OrgID: 1, Data: map[string]any{"name": "Batch Item 1"}},
 		{Key: dynamo.Key{PK: "BATCH2", SK: "S2"}, OrgID: 1, Data: map[string]any{"name": "Batch Item 2"}},
 		{Key: dynamo.Key{PK: "BATCH3", SK: "S3"}, OrgID: 1, Data: map[string]any{"name": "Batch Item 3"}},
@@ -88,16 +88,16 @@ func TestPutAndGet(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, unprocessed)
 
-	dyntest.AssertCount(t, client, "TestThings", 6)
+	dyntest.AssertCount(t, client, "TestPutAndGet", 6)
 
 	// batch get with empty keys
-	items, unprocessedKeys, err := dynamo.BatchGetItem(ctx, client, "TestThings", []dynamo.Key{})
+	items, unprocessedKeys, err := dynamo.BatchGetItem(ctx, client, "TestPutAndGet", []dynamo.Key{})
 	assert.NoError(t, err)
 	assert.Nil(t, items)
 	assert.Nil(t, unprocessedKeys)
 
 	// batch get existing items
-	items, unprocessedKeys, err = dynamo.BatchGetItem(ctx, client, "TestThings", []dynamo.Key{
+	items, unprocessedKeys, err = dynamo.BatchGetItem(ctx, client, "TestPutAndGet", []dynamo.Key{
 		{PK: "BATCH1", SK: "S1"},
 		{PK: "BATCH3", SK: "S3"},
 	})
@@ -106,7 +106,7 @@ func TestPutAndGet(t *testing.T) {
 	assert.Empty(t, unprocessedKeys)
 
 	// batch get with mix of existing and non-existing keys
-	items, unprocessedKeys, err = dynamo.BatchGetItem(ctx, client, "TestThings", []dynamo.Key{
+	items, unprocessedKeys, err = dynamo.BatchGetItem(ctx, client, "TestPutAndGet", []dynamo.Key{
 		{PK: "P11", SK: "SAA"},
 		{PK: "NOTEXIST", SK: "NOPE"},
 	})

--- a/aws/dynamo/spool_test.go
+++ b/aws/dynamo/spool_test.go
@@ -21,9 +21,10 @@ func TestSpool(t *testing.T) {
 	ctx := t.Context()
 
 	uuids.SetGenerator(uuids.NewSeededGenerator(1234, dates.NewSequentialNow(time.Date(2025, 7, 25, 12, 0, 0, 0, time.UTC), time.Second)))
+	defer uuids.SetGenerator(uuids.DefaultGenerator)
 
 	client, err := dynamo.NewClient(ctx, "http://localstack:4566")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	defer dyntest.Drop(t, client, "TestSpool")
 
@@ -33,12 +34,12 @@ func TestSpool(t *testing.T) {
 	item2, _ := attributevalue.MarshalMap(&dynamo.Item{Key: dynamo.Key{PK: "P22", SK: "SBB"}, OrgID: 1, Data: map[string]any{"name": "Thing 2", "count": 234}})
 	item3, _ := attributevalue.MarshalMap(&dynamo.Item{Key: dynamo.Key{PK: "P33", SK: "SAA"}, OrgID: 1, Data: map[string]any{"name": "Thing 3", "count": 345}})
 
-	spool := dynamo.NewSpool(client, "./_test_spool", 30*time.Second)
+	dir := filepath.Join(t.TempDir(), "spool")
 
-	defer spool.Delete()
+	spool := dynamo.NewSpool(client, dir, 30*time.Second)
 
 	err = spool.Start()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = spool.Add("TestSpool", []map[string]types.AttributeValue{item1, item2})
 	assert.NoError(t, err)
@@ -46,26 +47,26 @@ func TestSpool(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 3, spool.Size())
-	assert.FileExists(t, "./_test_spool/01984174-5600-7000-8e0f-6b2abe4360d8#2.jsonl")
-	assert.FileExists(t, "./_test_spool/01984174-59e8-7000-9a98-cfcce3019710#1.jsonl")
+	assert.FileExists(t, filepath.Join(dir, "01984174-5600-7000-8e0f-6b2abe4360d8#2.jsonl"))
+	assert.FileExists(t, filepath.Join(dir, "01984174-59e8-7000-9a98-cfcce3019710#1.jsonl"))
 
 	spool.Stop()
 
-	// Start new spool to verify it can read the existing spool files
-	spool = dynamo.NewSpool(client, "./_test_spool", 100*time.Millisecond)
-	spool.Start()
+	// start new spool to verify it can read the existing spool files.. and flush explicitly because flushing on the
+	// interval is covered by the spools package tests
+	spool = dynamo.NewSpool(client, dir, 30*time.Second)
+	require.NoError(t, spool.Start())
+	defer spool.Stop()
+
 	assert.Equal(t, 3, spool.Size())
 
-	// Give spool time to try a flush
-	time.Sleep(200 * time.Millisecond)
-
+	require.NoError(t, spool.Flush())
 	assert.Equal(t, 0, spool.Size())
 
 	obj, err := dynamo.GetItem(ctx, client, "TestSpool", dynamo.Key{PK: "P11", SK: "SAA"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.NotNil(t, obj)
 	assert.Equal(t, "Thing 1", obj.Data["name"])
-
-	spool.Stop()
 }
 
 func TestSpoolMixedTableFile(t *testing.T) {

--- a/aws/dynamo/writer_test.go
+++ b/aws/dynamo/writer_test.go
@@ -2,6 +2,7 @@ package dynamo_test
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -30,12 +31,11 @@ func TestWriter(t *testing.T) {
 
 	createTestTable(t, client, "TestWriter")
 
-	spool := dynamo.NewSpool(client, "./_test_spool", 30*time.Second)
-	spool.Start()
+	spool := dynamo.NewSpool(client, filepath.Join(t.TempDir(), "spool"), 30*time.Second)
+	require.NoError(t, spool.Start())
 
-	defer spool.Delete()
-
-	writer := dynamo.NewWriter(client, "TestWriter", 100*time.Millisecond, 10, spool)
+	// long max age because we flush explicitly.. flushing on max age is covered by the syncx batcher tests
+	writer := dynamo.NewWriter(client, "TestWriter", time.Minute, 10, spool)
 
 	assert.Equal(t, client, writer.Client())
 	assert.Equal(t, "TestWriter", writer.Table())
@@ -52,8 +52,7 @@ func TestWriter(t *testing.T) {
 	_, err = writer.Queue(&Thing{ID: 9, Name: "Item 9 v2"})
 	assert.NoError(t, err)
 
-	// allow time for writes to process
-	time.Sleep(200 * time.Millisecond)
+	writer.Flush()
 
 	numWritten, numSpooled := writer.Stats()
 	assert.Equal(t, int64(10), numWritten)
@@ -64,7 +63,8 @@ func TestWriter(t *testing.T) {
 
 	// check that last version of item9 was written
 	item, err := dynamo.GetItem(t.Context(), client, "TestWriter", dynamo.Key{PK: "test", SK: "item9"})
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.NotNil(t, item)
 	assert.Equal(t, "Item 9 v2", item.Data["Name"])
 
 	for i := range 5 {
@@ -77,17 +77,16 @@ func TestWriter(t *testing.T) {
 	assert.Equal(t, int64(15), numWritten)
 	assert.Equal(t, int64(0), numSpooled)
 
-	// Break writing by deleting the underlying table
+	// break writing by deleting the underlying table
 	dyntest.Drop(t, client, "TestWriter")
 
 	for i := range 5 {
 		writer.Queue(&Thing{ID: i + 15, Name: fmt.Sprintf("Item %d", i+15)})
 	}
 
-	// Allow time for writes to fail
-	time.Sleep(200 * time.Millisecond)
+	writer.Flush()
 
-	// And check they were spooled
+	// and check they were spooled
 	numWritten, numSpooled = writer.Stats()
 	assert.Equal(t, int64(15), numWritten)
 	assert.Equal(t, int64(5), numSpooled)

--- a/elastic/spool_test.go
+++ b/elastic/spool_test.go
@@ -15,13 +15,14 @@ import (
 
 func TestSpool(t *testing.T) {
 	uuids.SetGenerator(uuids.NewSeededGenerator(1234, dates.NewSequentialNow(time.Date(2025, 7, 25, 12, 0, 0, 0, time.UTC), time.Second)))
+	defer uuids.SetGenerator(uuids.DefaultGenerator)
 
 	createTestIndex(t, testClient, "test-spool")
 	defer deleteTestIndex(t, testClient, "test-spool")
 
-	spool := elastic.NewSpool(testClient, "./_test_spool", 30*time.Second)
+	dir := filepath.Join(t.TempDir(), "spool")
 
-	defer spool.Delete()
+	spool := elastic.NewSpool(testClient, dir, 30*time.Second)
 
 	err := spool.Start()
 	require.NoError(t, err)
@@ -38,28 +39,26 @@ func TestSpool(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, 3, spool.Size())
-	assert.FileExists(t, "./_test_spool/01984174-5600-7000-8e0f-6b2abe4360d8#2.jsonl")
-	assert.FileExists(t, "./_test_spool/01984174-59e8-7000-9a98-cfcce3019710#1.jsonl")
+	assert.FileExists(t, filepath.Join(dir, "01984174-5600-7000-8e0f-6b2abe4360d8#2.jsonl"))
+	assert.FileExists(t, filepath.Join(dir, "01984174-59e8-7000-9a98-cfcce3019710#1.jsonl"))
 
 	spool.Stop()
 
-	// start new spool to verify it can read existing spool files
-	spool = elastic.NewSpool(testClient, "./_test_spool", 100*time.Millisecond)
+	// start new spool to verify it can read existing spool files.. and flush explicitly because flushing on the
+	// interval is covered by the spools package tests
+	spool = elastic.NewSpool(testClient, dir, 30*time.Second)
 	err = spool.Start()
 	require.NoError(t, err)
+	defer spool.Stop()
 
 	assert.Equal(t, 3, spool.Size())
 
-	// give spool time to try a flush
-	time.Sleep(200 * time.Millisecond)
-
+	require.NoError(t, spool.Flush())
 	assert.Equal(t, 0, spool.Size())
 
 	// refresh and verify all items were indexed
 	refreshIndex(t, testClient, "test-spool")
 	assertCount(t, testClient, "test-spool", 3)
-
-	spool.Stop()
 }
 
 func TestSpoolStartDirectoryErrors(t *testing.T) {

--- a/elastic/writer_test.go
+++ b/elastic/writer_test.go
@@ -2,6 +2,7 @@ package elastic_test
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -16,13 +17,12 @@ func TestWriter(t *testing.T) {
 	createTestIndex(t, testClient, "test-writer")
 	defer deleteTestIndex(t, testClient, "test-writer")
 
-	spool := elastic.NewSpool(testClient, "./_test_spool", 30*time.Second)
+	spool := elastic.NewSpool(testClient, filepath.Join(t.TempDir(), "spool"), 30*time.Second)
 	err := spool.Start()
 	require.NoError(t, err)
 
-	defer spool.Delete()
-
-	writer := elastic.NewWriter(testClient, 25, 100*time.Millisecond, 10, spool)
+	// long max age because we flush explicitly.. flushing on max age is covered by the syncx batcher tests
+	writer := elastic.NewWriter(testClient, 25, time.Minute, 10, spool)
 
 	assert.Equal(t, testClient, writer.Client())
 
@@ -33,8 +33,7 @@ func TestWriter(t *testing.T) {
 		assert.NotZero(t, rem)
 	}
 
-	// allow time for writes to process
-	time.Sleep(200 * time.Millisecond)
+	writer.Flush()
 
 	numWritten, numSpooled := writer.Stats()
 	assert.Equal(t, int64(10), numWritten)
@@ -60,15 +59,14 @@ func TestWriter(t *testing.T) {
 	badClient, err := elastic.NewClient("http://localhost:19999", "", "")
 	require.NoError(t, err)
 
-	badWriter := elastic.NewWriter(badClient, 25, 100*time.Millisecond, 10, spool)
+	badWriter := elastic.NewWriter(badClient, 25, time.Minute, 10, spool)
 	badWriter.Start()
 
 	for i := range 5 {
 		badWriter.Queue(&elastic.Document{Index: "test-writer", ID: fmt.Sprintf("%d", i+15), Routing: "test", Body: []byte(fmt.Sprintf(`{"value": %d}`, i+15))})
 	}
 
-	// allow time for writes to fail
-	time.Sleep(200 * time.Millisecond)
+	badWriter.Flush()
 
 	// and check they were spooled
 	numWritten, numSpooled = badWriter.Stats()

--- a/syncx/batcher.go
+++ b/syncx/batcher.go
@@ -3,6 +3,7 @@ package syncx
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -12,10 +13,11 @@ type Batcher[T any] struct {
 	maxItems int
 	maxAge   time.Duration
 
-	buffer  chan T
-	force   chan *sync.WaitGroup
-	batch   []T
-	timeout <-chan time.Time
+	buffer    chan T
+	force     chan *sync.WaitGroup
+	batch     []T          // only accessed by the background goroutine
+	batchSize atomic.Int64 // mirrors len(batch) for reading from other goroutines
+	timeout   <-chan time.Time
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -50,6 +52,7 @@ func (b *Batcher[T]) Start(wg *sync.WaitGroup) {
 			select {
 			case v := <-b.buffer:
 				b.batch = append(b.batch, v)
+				b.batchSize.Store(int64(len(b.batch)))
 
 				// if this is the first item in the batch we need to restart the age timeout
 				if b.timeout == nil {
@@ -83,7 +86,7 @@ func (b *Batcher[T]) Start(wg *sync.WaitGroup) {
 func (b *Batcher[T]) Queue(value T) int {
 	b.buffer <- value
 
-	return (cap(b.batch) + cap(b.buffer)) - (len(b.batch) + len(b.buffer))
+	return (b.maxItems + cap(b.buffer)) - (int(b.batchSize.Load()) + len(b.buffer))
 }
 
 // Stop stops this batcher.
@@ -104,6 +107,7 @@ func (b *Batcher[T]) flush() {
 	if len(b.batch) > 0 {
 		b.process(b.batch)
 		b.batch = make([]T, 0, b.maxItems)
+		b.batchSize.Store(0)
 		b.timeout = nil
 	}
 }
@@ -118,6 +122,7 @@ func (b *Batcher[T]) drain() {
 			v := <-b.buffer
 			b.batch = append(b.batch, v)
 		}
+		b.batchSize.Store(int64(len(b.batch)))
 
 		b.flush()
 	}

--- a/syncx/batcher_test.go
+++ b/syncx/batcher_test.go
@@ -1,6 +1,7 @@
 package syncx_test
 
 import (
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -10,11 +11,21 @@ import (
 )
 
 func TestBatcher(t *testing.T) {
-	batches := make([][]int, 0)
+	// process callback runs in the batcher goroutine so access to recorded batches needs to be synchronized
+	var mu sync.Mutex
+	all := make([][]int, 0)
 
 	b := syncx.NewBatcher(func(batch []int) {
-		batches = append(batches, batch)
+		mu.Lock()
+		defer mu.Unlock()
+		all = append(all, batch)
 	}, 2, time.Second, 3)
+
+	batches := func() [][]int {
+		mu.Lock()
+		defer mu.Unlock()
+		return slices.Clone(all)
+	}
 
 	wg := &sync.WaitGroup{}
 	b.Start(wg)
@@ -22,36 +33,36 @@ func TestBatcher(t *testing.T) {
 	assert.Equal(t, 4, b.Queue(1)) // won't trigger a batch
 
 	time.Sleep(time.Millisecond * 100)
-	assert.Equal(t, [][]int{}, batches)
+	assert.Equal(t, [][]int{}, batches())
 
 	b.Queue(2) // 2 items triggers a batch
 
 	time.Sleep(time.Millisecond * 100)
-	assert.Equal(t, [][]int{{1, 2}}, batches)
+	assert.Equal(t, [][]int{{1, 2}}, batches())
 
 	b.Queue(3)
 	b.Queue(4)
 
 	time.Sleep(time.Millisecond * 100)
-	assert.Equal(t, [][]int{{1, 2}, {3, 4}}, batches)
+	assert.Equal(t, [][]int{{1, 2}, {3, 4}}, batches())
 
 	b.Queue(5)
 
 	time.Sleep(time.Millisecond * 100) // won't trigger a batch
-	assert.Equal(t, [][]int{{1, 2}, {3, 4}}, batches)
+	assert.Equal(t, [][]int{{1, 2}, {3, 4}}, batches())
 
 	time.Sleep(time.Millisecond * 1100) // batch forced because of age
-	assert.Equal(t, [][]int{{1, 2}, {3, 4}, {5}}, batches)
+	assert.Equal(t, [][]int{{1, 2}, {3, 4}, {5}}, batches())
 
 	time.Sleep(time.Millisecond * 1100) // empty batches never triggered
-	assert.Equal(t, [][]int{{1, 2}, {3, 4}, {5}}, batches)
+	assert.Equal(t, [][]int{{1, 2}, {3, 4}, {5}}, batches())
 
 	b.Queue(6)
 	b.Queue(7)
 	b.Queue(8)
 	b.Flush()
 
-	assert.Equal(t, [][]int{{1, 2}, {3, 4}, {5}, {6, 7}, {8}}, batches)
+	assert.Equal(t, [][]int{{1, 2}, {3, 4}, {5}, {6, 7}, {8}}, batches())
 
 	b.Queue(9)
 	b.Queue(10)
@@ -60,7 +71,7 @@ func TestBatcher(t *testing.T) {
 	b.Stop()
 	wg.Wait()
 
-	assert.Equal(t, [][]int{{1, 2}, {3, 4}, {5}, {6, 7}, {8}, {9, 10}, {11}}, batches)
+	assert.Equal(t, [][]int{{1, 2}, {3, 4}, {5}, {6, 7}, {8}, {9, 10}, {11}}, batches())
 
 	// panic if you try to queue to a stopped batcher
 	assert.Panics(t, func() {


### PR DESCRIPTION
## What changed

**Test determinism** — the `aws/dynamo` and `elastic` spool/writer tests failed intermittently in CI (e.g. runs 30121758937, 29961552611, 29617394783). Three causes:

- **Sleeps racing background flushes**: tests slept 200ms while a 100ms-interval spool flush (or 100ms-maxAge batcher flush) ran against localstack/Elasticsearch; under load the write outlives the sleep, the assertion fires mid-flush, and test teardown then cancels the in-flight request (the `context canceled` errors in the logs). The tests now use long intervals and the synchronous `Flush()` methods — timer-driven flushing is already unit-tested in `spools` and `syncx` against fake stores, so the integration tests no longer depend on timing at all.
- **Nil-pointer panic**: `dynamo.GetItem` returns `(nil, nil)` for a missing item and the writer test dereferenced the result after only `assert.NoError`, so a late write became a SIGSEGV that killed the whole package's test binary. Now guarded with `require.NoError` + `require.NotNil`.
- **Shared state between tests**: TestSpool and TestWriter shared a `./_test_spool` directory, so one failed test's leftover files contaminated the next test's spool size and were flushed to since-dropped tables (`ResourceNotFoundException` noise). Each test now uses `t.TempDir()`. Also renamed TestPutAndGet's table so it can't collide with the `dyntest` package's tests when packages run in parallel (CI's `-p=1` masked this).

**Data race fix in `syncx.Batcher`** — found while verifying with `-race`: `Queue()` read `len`/`cap` of the batch slice while the background goroutine reassigns it. The batch length is now mirrored in an atomic counter (`cap` is always `maxItems`). The batcher test's recorded-batches slice is also now mutex-guarded so the package is race-clean.

## Verification

- Full suite green with `-p=1 -count=1 ./...`
- Affected tests green with `-count=20` and with `-count=5 -race`