### PR TITLE
Use dynamodb-local instead of localstack for DynamoDB in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,13 @@ jobs:
       localstack:
         image: localstack/localstack:4.14
         env:
-          SERVICES: s3,dynamodb,cloudwatch
+          SERVICES: s3,cloudwatch
         ports:
           - 4566:4566
+      dynamodb:
+        image: amazon/dynamodb-local:3.3.1
+        ports:
+          - 8000:8000
 
     steps:
       - name: Checkout code

--- a/aws/dynamo/dyntest/ops_test.go
+++ b/aws/dynamo/dyntest/ops_test.go
@@ -11,7 +11,7 @@ import (
 func TestOps(t *testing.T) {
 	ctx := t.Context()
 
-	client, err := dynamo.NewClient(ctx, "http://localstack:4566")
+	client, err := dynamo.NewClient(ctx, "http://dynamodb:8000")
 	assert.NoError(t, err)
 
 	dyntest.CreateTables(t, client, "./testdata/tables.json", true)

--- a/aws/dynamo/dyntest/setup_test.go
+++ b/aws/dynamo/dyntest/setup_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// TestMain exports the standard AWS_* env vars so the SDK default credential chain resolves against localstack.
+// TestMain exports the standard AWS_* env vars so the SDK default credential chain resolves against dynamodb-local.
 func TestMain(m *testing.M) {
 	os.Setenv("AWS_ACCESS_KEY_ID", "root")
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "tembatemba")

--- a/aws/dynamo/ops_test.go
+++ b/aws/dynamo/ops_test.go
@@ -43,7 +43,7 @@ func createTestTable(t *testing.T, client *dynamodb.Client, name string) {
 func TestPutAndGet(t *testing.T) {
 	ctx := t.Context()
 
-	client, err := dynamo.NewClient(ctx, "http://localstack:4566")
+	client, err := dynamo.NewClient(ctx, "http://dynamodb:8000")
 	assert.NoError(t, err)
 
 	defer dyntest.Drop(t, client, "TestPutAndGet")

--- a/aws/dynamo/setup_test.go
+++ b/aws/dynamo/setup_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// TestMain exports the standard AWS_* env vars so the SDK default credential chain resolves against localstack.
+// TestMain exports the standard AWS_* env vars so the SDK default credential chain resolves against dynamodb-local.
 func TestMain(m *testing.M) {
 	os.Setenv("AWS_ACCESS_KEY_ID", "root")
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "tembatemba")

--- a/aws/dynamo/spool_test.go
+++ b/aws/dynamo/spool_test.go
@@ -23,7 +23,7 @@ func TestSpool(t *testing.T) {
 	uuids.SetGenerator(uuids.NewSeededGenerator(1234, dates.NewSequentialNow(time.Date(2025, 7, 25, 12, 0, 0, 0, time.UTC), time.Second)))
 	defer uuids.SetGenerator(uuids.DefaultGenerator)
 
-	client, err := dynamo.NewClient(ctx, "http://localstack:4566")
+	client, err := dynamo.NewClient(ctx, "http://dynamodb:8000")
 	require.NoError(t, err)
 
 	defer dyntest.Drop(t, client, "TestSpool")
@@ -72,7 +72,7 @@ func TestSpool(t *testing.T) {
 func TestSpoolMixedTableFile(t *testing.T) {
 	ctx := t.Context()
 
-	client, err := dynamo.NewClient(ctx, "http://localstack:4566")
+	client, err := dynamo.NewClient(ctx, "http://dynamodb:8000")
 	require.NoError(t, err)
 
 	defer dyntest.Drop(t, client, "TestSpoolMixed1")

--- a/aws/dynamo/writer_test.go
+++ b/aws/dynamo/writer_test.go
@@ -26,7 +26,7 @@ func (t *Thing) MarshalDynamo() (*dynamo.Item, error) {
 }
 
 func TestWriter(t *testing.T) {
-	client, err := dynamo.NewClient(t.Context(), "http://localstack:4566")
+	client, err := dynamo.NewClient(t.Context(), "http://dynamodb:8000")
 	require.NoError(t, err)
 
 	createTestTable(t, client, "TestWriter")


### PR DESCRIPTION
Points the test suite at a dedicated `amazon/dynamodb-local` service (`http://dynamodb:8000`) instead of localstack's DynamoDB, and adds that service to CI (localstack there now provides S3/CloudWatch only).

dynamodb-local is the same engine localstack wraps for DynamoDB, so behavior is unchanged — but it is officially maintained, much lighter, and supports persistence, which localstack's Community edition license-gated. The shared dev services stack now runs it alongside localstack, so devcontainer test runs reach it on the same hostname CI uses.