### PR TITLE
Add svclogs package and context-scoped trace collection to httpx

### DIFF
--- a/httpx/traces.go
+++ b/httpx/traces.go
@@ -2,6 +2,7 @@ package httpx
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -140,6 +141,13 @@ func (t *TracesTransport) RoundTrip(request *http.Request) (*http.Response, erro
 	t.mutex.Lock()
 	t.traces = append(t.traces, trace)
 	t.mutex.Unlock()
+
+	// also record into the per-call collector carried by the request context, if there is one, so that a caller
+	// sharing this transport can pick out the traces of just its own call
+	if c := traceCollectorFromContext(request.Context()); c != nil {
+		c.add(trace)
+	}
+
 	defer func() { trace.EndTime = dates.Now() }()
 
 	response, err := t.inner.RoundTrip(request)
@@ -180,6 +188,64 @@ func (t *TracesTransport) Traces() []*Trace {
 }
 
 var _ http.RoundTripper = (*TracesTransport)(nil)
+
+type traceCollectorKey struct{}
+
+// TraceCollector accumulates the traces of the requests made under a particular context. It is safe for concurrent
+// use by multiple goroutines.
+type TraceCollector struct {
+	mutex  sync.Mutex
+	traces []*Trace
+}
+
+// WithTraceCollector returns a copy of ctx carrying a fresh TraceCollector, along with that collector. Any request
+// made with the returned context through a transport wrapped by WithTraces records its trace into the collector.
+//
+// This is how a caller captures the traces of just its own call while the client, and the tracing transport on it,
+// are shared - so the tracing can be installed once when the client is built rather than assembled per call. It also
+// works when the request is issued by code the caller doesn't control, such as a vendor SDK given the client at
+// construction: pass the context into the SDK call and the traces come back here.
+//
+//	client := &http.Client{Transport: httpx.WithTraces(base)} // once
+//
+//	ctx, traces := httpx.WithTraceCollector(ctx)              // per call
+//	resp, err := client.Do(req.WithContext(ctx))
+//	trace := traces.Last()
+func WithTraceCollector(ctx context.Context) (context.Context, *TraceCollector) {
+	c := &TraceCollector{}
+	return context.WithValue(ctx, traceCollectorKey{}, c), c
+}
+
+// traceCollectorFromContext returns the collector carried in ctx, or nil if none was installed.
+func traceCollectorFromContext(ctx context.Context) *TraceCollector {
+	c, _ := ctx.Value(traceCollectorKey{}).(*TraceCollector)
+	return c
+}
+
+func (c *TraceCollector) add(t *Trace) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.traces = append(c.traces, t)
+}
+
+// Traces returns a snapshot of the traces collected so far, in the order the requests were made.
+func (c *TraceCollector) Traces() []*Trace {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	return slices.Clone(c.traces)
+}
+
+// Last returns the most recently started trace, or nil if none were collected. Where a request was redirected that's
+// the final hop, which is usually the only one worth logging - the earlier hops being the 3xx responses that led to
+// it. A nil return means no request reached the tracing transport at all.
+func (c *TraceCollector) Last() *Trace {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if len(c.traces) == 0 {
+		return nil
+	}
+	return c.traces[len(c.traces)-1]
+}
 
 // errReader is an io.Reader that always returns its error, used to replay a body read failure to the caller
 type errReader struct{ err error }

--- a/httpx/traces_test.go
+++ b/httpx/traces_test.go
@@ -3,6 +3,7 @@ package httpx_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"sync"
@@ -210,4 +211,127 @@ func TestNonUTF8Response(t *testing.T) {
 	sanitized := trace.SanitizedResponse("...")
 	assert.Equal(t, "HTTP/1.0 200 OK\r\nContent-Length: 2\r\nX-Badness: �(\r\n\r\n...", sanitized)
 	assert.True(t, utf8.Valid([]byte(sanitized)))
+}
+
+// roundTripFunc adapts a function to an http.RoundTripper for tests.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestTraceCollector(t *testing.T) {
+	const url = "https://example.com/thing"
+
+	// the tracing transport is installed once, on a shared client
+	client := &http.Client{Transport: httpx.WithTraces(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+		url: {httpx.NewMockResponse(200, nil, []byte("hello")), httpx.NewMockResponse(200, nil, []byte("again"))},
+	}))}
+
+	// a call made with a collector in its context can pick out its own trace
+	ctx, traces := httpx.WithTraceCollector(context.Background())
+	req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	require.Len(t, traces.Traces(), 1)
+	require.NotNil(t, traces.Last())
+	assert.Equal(t, []byte("hello"), traces.Last().ResponseBody)
+
+	// a second call gets its own collector, unpolluted by the first
+	ctx2, traces2 := httpx.WithTraceCollector(context.Background())
+	req2, _ := http.NewRequestWithContext(ctx2, "GET", url, nil)
+	_, err = client.Do(req2)
+	require.NoError(t, err)
+
+	assert.Len(t, traces.Traces(), 1, "first collector should not see the second call")
+	require.Len(t, traces2.Traces(), 1)
+	assert.Equal(t, []byte("again"), traces2.Last().ResponseBody)
+
+	// a redirect records every hop, and Last is the final one
+	redirectClient := &http.Client{Transport: httpx.WithTraces(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+		"https://example.com/redirect": {httpx.NewMockResponse(302, map[string]string{"Location": url}, nil)},
+		url:                            {httpx.NewMockResponse(200, nil, []byte("final"))},
+	}))}
+	ctx3, traces3 := httpx.WithTraceCollector(context.Background())
+	req3, _ := http.NewRequestWithContext(ctx3, "GET", "https://example.com/redirect", nil)
+	_, err = redirectClient.Do(req3)
+	require.NoError(t, err)
+
+	assert.Len(t, traces3.Traces(), 2)
+	assert.Equal(t, 200, traces3.Last().Response.StatusCode)
+	assert.Equal(t, []byte("final"), traces3.Last().ResponseBody)
+
+	// requests made without a collector still work, and are still recorded by the transport itself
+	tracer := httpx.WithTraces(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+		url: {httpx.NewMockResponse(200, nil, []byte("solo"))},
+	}))
+	req4, _ := http.NewRequest("GET", url, nil)
+	_, err = (&http.Client{Transport: tracer}).Do(req4)
+	require.NoError(t, err)
+	assert.Len(t, tracer.Traces(), 1)
+
+	// an empty collector reports no traces rather than panicking
+	_, empty := httpx.WithTraceCollector(context.Background())
+	assert.Empty(t, empty.Traces())
+	assert.Nil(t, empty.Last())
+}
+
+func TestTraceCollectorConcurrent(t *testing.T) {
+	client := &http.Client{Transport: httpx.WithTraces(roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{Status: "200 OK", StatusCode: 200, Proto: "HTTP/1.1", ProtoMajor: 1, ProtoMinor: 1,
+			Header: make(http.Header), Body: io.NopCloser(bytes.NewReader([]byte(r.URL.Path)))}, nil
+	}))}
+
+	// each concurrent caller must see exactly its own trace, not those of the calls racing alongside it
+	wg := sync.WaitGroup{}
+	for i := range 50 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+
+			ctx, traces := httpx.WithTraceCollector(context.Background())
+			path := fmt.Sprintf("/req-%d", i)
+			req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com"+path, nil)
+			_, err := client.Do(req)
+
+			assert.NoError(t, err)
+			if assert.Len(t, traces.Traces(), 1) {
+				assert.Equal(t, []byte(path), traces.Last().ResponseBody)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestTraceCollectorWithRetries(t *testing.T) {
+	// a retrier composed inside the tracer reports its retries on the collected trace
+	client := &http.Client{Transport: httpx.WithTraces(httpx.WithRetries(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+		"https://example.com/thing": {httpx.NewMockResponse(502, nil, nil), httpx.NewMockResponse(200, nil, []byte("ok"))},
+	}), httpx.NewFixedRetries(time.Millisecond)))}
+
+	ctx, traces := httpx.WithTraceCollector(context.Background())
+	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/thing", nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	require.Len(t, traces.Traces(), 1)
+	assert.Equal(t, 1, traces.Last().Retries)
+	assert.Equal(t, []byte("ok"), traces.Last().ResponseBody)
+}
+
+func TestTraceCollectorReadLimit(t *testing.T) {
+	// the read limit stays a transport concern, composed inside the tracer on the client
+	client := &http.Client{Transport: httpx.WithTraces(httpx.WithReadLimit(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+		"https://example.com/big": {httpx.NewMockResponse(200, nil, bytes.Repeat([]byte("x"), 100))},
+	}), 10))}
+
+	ctx, traces := httpx.WithTraceCollector(context.Background())
+	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com/big", nil)
+	resp, err := client.Do(req)
+	require.NoError(t, err) // the limit is enforced when the body is read, not by Do
+
+	_, err = io.ReadAll(resp.Body)
+	assert.ErrorIs(t, err, httpx.ErrResponseSize)
+	require.NotNil(t, traces.Last())
 }

--- a/svclogs/log.go
+++ b/svclogs/log.go
@@ -1,0 +1,105 @@
+// Package svclogs provides a log of an interaction with an external service - the HTTP requests made, any errors
+// that occurred, and how long it took. Values which shouldn't be persisted (API keys, tokens) are redacted as they're
+// added. Callers typically embed Log in their own type to attach whatever identifies the interaction for them, e.g.
+// the channel it was for.
+package svclogs
+
+import (
+	"time"
+
+	"github.com/nyaruka/gocommon/dates"
+	"github.com/nyaruka/gocommon/httpx"
+	"github.com/nyaruka/gocommon/stringsx"
+	"github.com/nyaruka/gocommon/uuids"
+)
+
+// UUID is the type of a service log UUID (should be v7)
+type UUID uuids.UUID
+
+// NewUUID creates a new service log UUID
+func NewUUID() UUID {
+	return UUID(uuids.NewV7())
+}
+
+// Type distinguishes the kinds of interaction a log can record, and is defined by the caller
+type Type string
+
+// Error is an error that occurred during a service interaction
+type Error struct {
+	Code    string `json:"code"`
+	ExtCode string `json:"ext_code,omitempty"`
+	Message string `json:"message"`
+}
+
+// Redact applies the given redactor to this error
+func (e *Error) Redact(r stringsx.Redactor) *Error {
+	return &Error{Code: e.Code, ExtCode: e.ExtCode, Message: r(e.Message)}
+}
+
+// Log is the basic service log structure
+type Log struct {
+	UUID      UUID
+	Type      Type
+	HttpLogs  []*httpx.Log
+	Errors    []*Error
+	CreatedOn time.Time
+	Elapsed   time.Duration
+
+	recorder *httpx.Recorder
+	redactor stringsx.Redactor
+}
+
+// New creates a new log of the given type. Pass a recorder when the interaction was triggered by an incoming request
+// which should itself be included in the log, and the values (tokens, secrets) to redact from everything added to it.
+func New(t Type, r *httpx.Recorder, redactVals []string) *Log {
+	return &Log{
+		UUID:      NewUUID(),
+		Type:      t,
+		HttpLogs:  []*httpx.Log{},
+		Errors:    []*Error{},
+		CreatedOn: dates.Now(),
+
+		recorder: r,
+		redactor: stringsx.NewRedactor("**********", redactVals...),
+	}
+}
+
+// HTTP adds the given HTTP trace to this log
+func (l *Log) HTTP(t *httpx.Trace) {
+	l.HttpLogs = append(l.HttpLogs, l.traceToLog(t))
+}
+
+// Error adds the given error to this log
+func (l *Log) Error(e *Error) {
+	l.Errors = append(l.Errors, e.Redact(l.redactor))
+}
+
+// End finalizes this log
+func (l *Log) End() {
+	if l.recorder != nil {
+		// prepend so it's the first HTTP request in the log
+		l.HttpLogs = append([]*httpx.Log{l.traceToLog(l.recorder.Trace)}, l.HttpLogs...)
+	}
+
+	l.Elapsed = dates.Now().Sub(l.CreatedOn)
+}
+
+// IsError returns whether this log should be considered an error - i.e. we recorded an error or a non 2XX/3XX
+// HTTP response
+func (l *Log) IsError() bool {
+	if len(l.Errors) > 0 {
+		return true
+	}
+
+	for _, l := range l.HttpLogs {
+		if l.StatusCode < 200 || l.StatusCode >= 400 {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (l *Log) traceToLog(t *httpx.Trace) *httpx.Log {
+	return httpx.NewLog(t, 2048, 50000, l.redactor)
+}

--- a/svclogs/log_test.go
+++ b/svclogs/log_test.go
@@ -1,0 +1,62 @@
+package svclogs_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/nyaruka/gocommon/httpx"
+	"github.com/nyaruka/gocommon/svclogs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogs(t *testing.T) {
+	// tracing is installed once on the shared client; each call collects its own traces via the context
+	client := &http.Client{Transport: httpx.WithTraces(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+		"http://ivr.com/start":  {httpx.NewMockResponse(200, nil, []byte("OK"))},
+		"http://ivr.com/hangup": {httpx.NewMockResponse(400, nil, []byte("Oops"))},
+	}))}
+
+	do := func(t *testing.T, method, url string, headers map[string]string) *httpx.Trace {
+		t.Helper()
+
+		ctx, traces := httpx.WithTraceCollector(context.Background())
+		req, err := httpx.NewRequest(ctx, method, url, nil, headers)
+		require.NoError(t, err)
+		_, err = client.Do(req)
+		require.NoError(t, err)
+
+		return traces.Last()
+	}
+
+	log1 := svclogs.New("type1", nil, []string{"sesame"})
+	log1.HTTP(do(t, "GET", "http://ivr.com/start", map[string]string{"Authorization": "Token sesame"}))
+	log1.End()
+
+	log2 := svclogs.New("type1", nil, []string{"sesame"})
+	log2.HTTP(do(t, "GET", "http://ivr.com/hangup", nil))
+	log2.Error(&svclogs.Error{Message: "oops"})
+	log2.End()
+
+	assert.NotEqual(t, log1.UUID, log2.UUID)
+	assert.NotEqual(t, time.Duration(0), log1.Elapsed)
+
+	// a 2XX response and no errors isn't an error
+	assert.False(t, log1.IsError())
+
+	// a 4XX response is, as is a recorded error
+	assert.True(t, log2.IsError())
+
+	// redaction applies to values passed at construction, in both traces and errors
+	assert.NotContains(t, log1.HttpLogs[0].Request, "sesame")
+	assert.Contains(t, log1.HttpLogs[0].Request, "**********")
+
+	log3 := svclogs.New("type2", nil, []string{"sesame"})
+	log3.Error(&svclogs.Error{Code: "code1", ExtCode: "ext", Message: "contains sesame seeds"})
+	assert.Equal(t, "contains ********** seeds", log3.Errors[0].Message)
+	assert.Equal(t, "code1", log3.Errors[0].Code)
+	assert.Equal(t, "ext", log3.Errors[0].ExtCode)
+	assert.True(t, log3.IsError())
+}


### PR DESCRIPTION
## Summary

Adds two things that currently exist as near-identical private copies in the courier and mailroom services, so both can drop their local versions and share one implementation.

## Changes

**New `svclogs` package** — a log of an interaction with an external service: the HTTP requests made, any errors, and how long it took, with configured values redacted as they're added. Callers embed `svclogs.Log` in their own type to attach whatever identifies the interaction for them (e.g. the channel it was for). The two copies this replaces were byte-for-byte identical apart from the package name. Timestamps use `dates.Now()` rather than the wall clock the service-side copies used, so `CreatedOn` and `Elapsed` are mockable in tests like the trace times they sit alongside.

**New `httpx.WithTraceCollector`** — returns a context carrying a fresh `TraceCollector`, into which any request made with that context through a `WithTraces` transport records its trace.

```go
client := &http.Client{Transport: httpx.WithTraces(base)} // once, when the client is built

ctx, traces := httpx.WithTraceCollector(ctx)              // per call
resp, err := client.Do(req.WithContext(ctx))
trace := traces.Last()
```

This replaces the removed `httpx.DoTrace`, which both services had reimplemented locally with different signatures. Rather than restoring a `DoTrace(client, req)`-shaped helper, tracing stays a transport layer installed once on the client, and per-call state travels in the context — the same mechanism `WithTraces` already uses internally to let an inner retrier report its retry count back out.

The difference matters wherever the caller doesn't own the `Do`. A client with a tracing transport can be handed to a vendor SDK and still yield per-call traces, which a call-shaped helper cannot do at all. It also keeps the read limit composable (`WithTraces(WithReadLimit(inner, n))`) rather than making it a per-call argument.

`TracesTransport` keeps its own accumulating `Traces()` list, so existing users are unaffected — the collector is recorded into alongside it, and requests made without one behave exactly as before.

## Behavior

Purely additive. No existing exported function changes signature or behaviour; `WithTraces` gains the collector side effect, which is inert unless a caller installs one.

## Test plan

- [x] `go build ./...`, `go vet`, `gofmt -l` all clean
- [x] Full suite green in the devcontainer with the CI command (`go test -p=1 ./...`) — 23 packages, exit 0
- [x] CI green on this head — both required `Test` jobs and `CLAssistant`
- [x] `TestTraceCollector` — collection through a shared client, isolation between successive calls, every hop of a redirect recorded with `Last()` returning the final one, requests without a collector still recorded by the transport, and an empty collector reporting no traces rather than panicking
- [x] `TestTraceCollectorConcurrent` — 50 concurrent callers each see exactly their own trace
- [x] `TestTraceCollectorWithRetries` — a retrier composed inside the tracer reports its retries on the collected trace
- [x] `TestTraceCollectorReadLimit` — the read limit remains a transport concern and still surfaces `ErrResponseSize`
- [x] `TestLogs` — UUID uniqueness, elapsed time, `IsError` for both a recorded error and a 4XX response, and redaction of configured values in traces and errors

## Review notes

- The automated review flagged that `svclogs` used `time.Now()` where the rest of gocommon uses the mockable `dates.Now()`. Taken — it had been carried over verbatim from the service-side copy, where no such convention existed.
- An earlier revision of this PR added a call-shaped `httpx.TraceRequest(client, req, maxBodyBytes)` instead of the collector. It was reworked because that shape can't serve a client handed to a vendor SDK, which is precisely where these services need tracing and don't have it today.

## Note for reviewers

Running the suite without `-p=1` fails in `dbutil` and `dbutil/assertdb` — both create a table named `foo` in the same test database, so in parallel they clobber each other. That is pre-existing and unrelated to this change; CI already passes `-p=1`, which is why it doesn't show up there.