### PR TITLE
Make WithTraces record into context collectors only

### DIFF
--- a/httpx/limit_test.go
+++ b/httpx/limit_test.go
@@ -66,7 +66,8 @@ func TestBodyLimitTransport(t *testing.T) {
 	// composed inside WithTraces, the limit bounds the body before it's buffered, so the caller reading the
 	// handed-back body sees ErrResponseSize rather than WithTraces silently buffering the whole thing
 	tracing := httpx.WithTraces(httpx.WithReadLimit(http.DefaultTransport, 4))
-	request, err = httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
+	tracingCtx, _ := httpx.WithTraceCollector(ctx)
+	request, err = httpx.NewRequest(tracingCtx, "GET", server.URL+"?cmd=success", nil, nil)
 	require.NoError(t, err)
 	resp, err = tracing.RoundTrip(request)
 	require.NoError(t, err)

--- a/httpx/logs_test.go
+++ b/httpx/logs_test.go
@@ -27,11 +27,11 @@ func TestLogs(t *testing.T) {
 
 	// trace makes the given request through the tracing transport and returns the captured trace
 	trace := func(req *http.Request) *httpx.Trace {
-		resp, err := tt.RoundTrip(req)
+		ctx, traces := httpx.WithTraceCollector(req.Context())
+		resp, err := tt.RoundTrip(req.WithContext(ctx))
 		require.NoError(t, err)
 		resp.Body.Close()
-		traces := tt.Traces()
-		return traces[len(traces)-1]
+		return traces.Last()
 	}
 
 	req1, err := httpx.NewRequest(

--- a/httpx/retries.go
+++ b/httpx/retries.go
@@ -139,7 +139,7 @@ func WithRetries(inner http.RoundTripper, retries *RetryConfig) http.RoundTrippe
 }
 
 func (t *retryTransport) RoundTrip(request *http.Request) (*http.Response, error) {
-	// an outer TracesTransport may have installed a counter for us to report retries through
+	// an outer traces transport may have installed a counter for us to report retries through
 	count := retryCountFromContext(request.Context())
 
 	retry := 0
@@ -214,8 +214,8 @@ func wait(ctx context.Context, d time.Duration) error {
 	}
 }
 
-// retryCountKey is the unexported context key under which a retry counter is carried so that an outer TracesTransport
-// can recover how many retries an inner retryTransport performed. See WithRetries.
+// retryCountKey is the unexported context key under which a retry counter is carried so that an outer traces
+// transport can recover how many retries an inner retryTransport performed. See WithRetries.
 type retryCountKey struct{}
 
 // contextWithRetryCount returns a copy of ctx carrying a fresh retry counter, along with that counter. An outer

--- a/httpx/retries_test.go
+++ b/httpx/retries_test.go
@@ -271,7 +271,8 @@ func TestWithRetriesAndTraces(t *testing.T) {
 
 	// WithTraces(WithRetries(inner)) captures a single trace of the final attempt, with the retry count surfaced
 	tt := httpx.WithTraces(httpx.WithRetries(inner, retries))
-	req, err := httpx.NewRequest(ctx, "GET", "http://temba.io/", nil, nil)
+	traceCtx, traces := httpx.WithTraceCollector(ctx)
+	req, err := httpx.NewRequest(traceCtx, "GET", "http://temba.io/", nil, nil)
 	require.NoError(t, err)
 	resp, err := tt.RoundTrip(req)
 	require.NoError(t, err)
@@ -281,8 +282,8 @@ func TestWithRetriesAndTraces(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ok", string(body))
 
-	require.Len(t, tt.Traces(), 1)
-	trace := tt.Traces()[0]
+	require.Len(t, traces.Traces(), 1)
+	trace := traces.Last()
 	assert.Equal(t, 200, trace.Response.StatusCode)
 	assert.Equal(t, "ok", string(trace.ResponseBody))
 	assert.Equal(t, 2, trace.Retries)

--- a/httpx/traces.go
+++ b/httpx/traces.go
@@ -98,27 +98,39 @@ func replaceNullChars(b []byte) []byte {
 	return bytes.ReplaceAll(b, []byte{0}, []byte(`�`))
 }
 
-// TracesTransport is an http.RoundTripper which captures a Trace of each request and response, delegating to an
-// inner transport. The response body is buffered so that it remains readable by the caller. It is safe for
-// concurrent use by multiple goroutines, as the http.RoundTripper contract requires.
-type TracesTransport struct {
-	inner  http.RoundTripper
-	mutex  sync.Mutex
-	traces []*Trace
+// tracesTransport is an http.RoundTripper which captures a Trace of each request and response into the
+// TraceCollector carried by that request's context, delegating to an inner transport. The response body is buffered
+// so that it remains readable by the caller. It holds no state of its own and is safe for concurrent use by multiple
+// goroutines, as the http.RoundTripper contract requires.
+type tracesTransport struct {
+	inner http.RoundTripper
 }
 
-// WithTraces wraps an http.RoundTripper so that each request and response is captured as a *Trace, retrievable via
-// Traces(). The response body is buffered so it remains readable by the caller, and the full body that was read is
-// captured into the trace. To bound how many bytes are read from an untrusted endpoint, wrap the inner transport with
-// WithReadLimit, e.g. WithTraces(WithReadLimit(inner, n)). If inner is nil then http.DefaultTransport is used.
-func WithTraces(inner http.RoundTripper) *TracesTransport {
+// WithTraces wraps an http.RoundTripper so that each request whose context carries a TraceCollector (see
+// WithTraceCollector) has its request and response captured into that collector as a *Trace. The response body is
+// buffered so it remains readable by the caller, and the full body that was read is captured into the trace. To
+// bound how many bytes are read from an untrusted endpoint, wrap the inner transport with WithReadLimit, e.g.
+// WithTraces(WithReadLimit(inner, n)). If inner is nil then http.DefaultTransport is used.
+//
+// The transport accumulates nothing, so it belongs on the client when the client is built - including a long-lived
+// client shared across many calls, and one handed to a vendor SDK that will make the requests itself. A request
+// whose context carries no collector is passed straight through, untraced and with its body left unbuffered: nobody
+// asked for that call's trace, so none is taken and none of tracing's cost is paid.
+func WithTraces(inner http.RoundTripper) http.RoundTripper {
 	if inner == nil {
 		inner = http.DefaultTransport
 	}
-	return &TracesTransport{inner: inner}
+	return &tracesTransport{inner: inner}
 }
 
-func (t *TracesTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+func (t *tracesTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	collector := traceCollectorFromContext(request.Context())
+
+	// nobody asked for this call's trace, so take none
+	if collector == nil {
+		return t.inner.RoundTrip(request)
+	}
+
 	requestTrace, err := httputil.DumpRequestOut(request, true)
 	if err != nil {
 		// the http.RoundTripper contract requires the request body to be closed even on error paths
@@ -138,16 +150,12 @@ func (t *TracesTransport) RoundTrip(request *http.Request) (*http.Response, erro
 		RequestTrace: requestTrace,
 		StartTime:    dates.Now(),
 	}
-	t.mutex.Lock()
-	t.traces = append(t.traces, trace)
-	t.mutex.Unlock()
 
-	// also record into the per-call collector carried by the request context, if there is one, so that a caller
-	// sharing this transport can pick out the traces of just its own call
-	if c := traceCollectorFromContext(request.Context()); c != nil {
-		c.add(trace)
-	}
-
+	// hand the trace to the collector only once every field has been written. Deferring it (registered first, so it
+	// runs last) publishes it on every exit path, and the collector's lock then gives a reader in another goroutine
+	// the happens-before it needs - whereas publishing up front would expose a trace still being filled in, which
+	// only a collector that is never shared could get away with reading.
+	defer collector.add(trace)
 	defer func() { trace.EndTime = dates.Now() }()
 
 	response, err := t.inner.RoundTrip(request)
@@ -180,19 +188,16 @@ func (t *TracesTransport) RoundTrip(request *http.Request) (*http.Response, erro
 	return response, nil
 }
 
-// Traces returns a snapshot of the traces captured so far
-func (t *TracesTransport) Traces() []*Trace {
-	t.mutex.Lock()
-	defer t.mutex.Unlock()
-	return slices.Clone(t.traces)
-}
-
-var _ http.RoundTripper = (*TracesTransport)(nil)
+var _ http.RoundTripper = (*tracesTransport)(nil)
 
 type traceCollectorKey struct{}
 
-// TraceCollector accumulates the traces of the requests made under a particular context. It is safe for concurrent
-// use by multiple goroutines.
+// TraceCollector accumulates the traces of the requests made under a particular context. A trace appears here once
+// its request has completed, not while it is in flight, so what a reader sees is always fully written.
+//
+// It is safe for concurrent use by multiple goroutines. Note though that a context passed to several goroutines
+// gives them one shared collector: Traces() is then the union of what they all did, and Last() is simply the most
+// recent of those, not the caller's own. Where each caller needs its own traces, each needs its own collector.
 type TraceCollector struct {
 	mutex  sync.Mutex
 	traces []*Trace
@@ -235,9 +240,9 @@ func (c *TraceCollector) Traces() []*Trace {
 	return slices.Clone(c.traces)
 }
 
-// Last returns the most recently started trace, or nil if none were collected. Where a request was redirected that's
-// the final hop, which is usually the only one worth logging - the earlier hops being the 3xx responses that led to
-// it. A nil return means no request reached the tracing transport at all.
+// Last returns the most recently completed trace, or nil if none were collected. Where a request was redirected
+// that's the final hop, which is usually the only one worth logging - the earlier hops being the 3xx responses that
+// led to it. A nil return means no request reached the tracing transport at all.
 func (c *TraceCollector) Last() *Trace {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()

--- a/httpx/traces_test.go
+++ b/httpx/traces_test.go
@@ -28,7 +28,8 @@ func TestTracesTransport(t *testing.T) {
 
 	tt := httpx.WithTraces(http.DefaultTransport)
 
-	request, err := httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
+	traceCtx, traces := httpx.WithTraceCollector(ctx)
+	request, err := httpx.NewRequest(traceCtx, "GET", server.URL+"?cmd=success", nil, nil)
 	require.NoError(t, err)
 	resp, err := tt.RoundTrip(request)
 	require.NoError(t, err)
@@ -38,9 +39,9 @@ func TestTracesTransport(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, `{ "ok": "true" }`, string(body))
 
-	// and a complete trace was captured
-	require.Len(t, tt.Traces(), 1)
-	trace := tt.Traces()[0]
+	// and a complete trace was captured into the collector
+	require.Len(t, traces.Traces(), 1)
+	trace := traces.Traces()[0]
 	assert.Equal(t, "GET /?cmd=success HTTP/1.1\r\nHost: 127.0.0.1:52026\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip\r\n\r\n", string(trace.RequestTrace))
 	assert.Equal(t, "HTTP/1.1 200 OK\r\nContent-Length: 16\r\nContent-Type: text/plain; charset=utf-8\r\nDate: Wed, 11 Apr 2018 18:24:30 GMT\r\n\r\n", string(trace.ResponseTrace))
 	assert.Equal(t, `{ "ok": "true" }`, string(trace.ResponseBody))
@@ -48,18 +49,29 @@ func TestTracesTransport(t *testing.T) {
 	assert.Equal(t, time.Date(2019, 10, 7, 15, 21, 31, 123456789, time.UTC), trace.EndTime)
 	assert.Equal(t, 0, trace.Retries)
 
-	// a second request accumulates another trace
-	request, err = httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
+	// a second request under the same collector adds another trace
+	request, err = httpx.NewRequest(traceCtx, "GET", server.URL+"?cmd=success", nil, nil)
 	require.NoError(t, err)
 	resp, err = tt.RoundTrip(request)
 	require.NoError(t, err)
 	io.ReadAll(resp.Body)
-	assert.Len(t, tt.Traces(), 2)
+	assert.Len(t, traces.Traces(), 2)
+
+	// a request with no collector on its context is passed through untraced
+	request, err = httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
+	require.NoError(t, err)
+	resp, err = tt.RoundTrip(request)
+	require.NoError(t, err)
+	body, err = io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, `{ "ok": "true" }`, string(body))
+	assert.Len(t, traces.Traces(), 2, "untraced request must not reach the earlier collector")
 
 	// the inner transport still sees the request body after DumpRequestOut has consumed and restored it
 	capturer := &bodyCapturingTransport{}
 	tt = httpx.WithTraces(capturer)
-	request, err = httpx.NewRequest(ctx, "POST", "https://temba.io", bytes.NewReader([]byte("hello body")), nil)
+	capturerCtx, _ := httpx.WithTraceCollector(ctx)
+	request, err = httpx.NewRequest(capturerCtx, "POST", "https://temba.io", bytes.NewReader([]byte("hello body")), nil)
 	require.NoError(t, err)
 	resp, err = tt.RoundTrip(request)
 	require.NoError(t, err)
@@ -70,20 +82,22 @@ func TestTracesTransport(t *testing.T) {
 		"https://temba.io": {httpx.MockConnectionError},
 	})
 	tt = httpx.WithTraces(inner)
-	request, err = httpx.NewRequest(ctx, "GET", "https://temba.io", nil, nil)
+	errCtx, errTraces := httpx.WithTraceCollector(ctx)
+	request, err = httpx.NewRequest(errCtx, "GET", "https://temba.io", nil, nil)
 	require.NoError(t, err)
 	resp, err = tt.RoundTrip(request)
 	assert.EqualError(t, err, "unable to connect to server")
 	assert.Nil(t, resp)
-	require.Len(t, tt.Traces(), 1)
-	assert.NotNil(t, tt.Traces()[0].RequestTrace)
-	assert.Nil(t, tt.Traces()[0].Response)
-	assert.Nil(t, tt.Traces()[0].ResponseBody)
+	require.Len(t, errTraces.Traces(), 1)
+	assert.NotNil(t, errTraces.Last().RequestTrace)
+	assert.Nil(t, errTraces.Last().Response)
+	assert.Nil(t, errTraces.Last().ResponseBody)
 
 	// a nil inner transport falls back to http.DefaultTransport
 	tt = httpx.WithTraces(nil)
 	assert.NotNil(t, tt)
-	request, err = httpx.NewRequest(ctx, "GET", server.URL+"?cmd=success", nil, nil)
+	nilCtx, _ := httpx.WithTraceCollector(ctx)
+	request, err = httpx.NewRequest(nilCtx, "GET", server.URL+"?cmd=success", nil, nil)
 	require.NoError(t, err)
 	resp, err = tt.RoundTrip(request)
 	require.NoError(t, err)
@@ -110,21 +124,22 @@ func TestTracesTransportConcurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			request, _ := http.NewRequest("GET", server.URL+"?cmd=success", nil)
+
+			ctx, traces := httpx.WithTraceCollector(context.Background())
+			request, _ := http.NewRequestWithContext(ctx, "GET", server.URL+"?cmd=success", nil)
 			resp, err := tt.RoundTrip(request)
 			if assert.NoError(t, err) {
 				io.ReadAll(resp.Body)
 				resp.Body.Close()
 			}
+			assert.Len(t, traces.Traces(), 1) // each goroutine sees only its own
 		}()
 	}
 	wg.Wait()
-
-	assert.Len(t, tt.Traces(), 20)
 }
 
 func TestTraceSizes(t *testing.T) {
-	ctx := context.Background()
+	ctx, traces := httpx.WithTraceCollector(context.Background())
 
 	tt := httpx.WithTraces(httpx.WithMocks(http.DefaultTransport, map[string][]*httpx.MockResponse{
 		"https://temba.io": {
@@ -139,7 +154,7 @@ func TestTraceSizes(t *testing.T) {
 	require.NoError(t, err)
 	resp.Body.Close()
 
-	trace := tt.Traces()[0]
+	trace := traces.Last()
 	assert.Equal(t, len(trace.RequestTrace), trace.RequestSize())
 	assert.Equal(t, len(trace.ResponseTrace)+12, trace.ResponseSize())
 
@@ -158,7 +173,7 @@ func TestTraceSizes(t *testing.T) {
 }
 
 func TestNonUTF8Request(t *testing.T) {
-	ctx := context.Background()
+	ctx, traces := httpx.WithTraceCollector(context.Background())
 
 	tt := httpx.WithTraces(httpx.WithMocks(http.DefaultTransport, map[string][]*httpx.MockResponse{
 		"https://temba.io": {
@@ -173,7 +188,7 @@ func TestNonUTF8Request(t *testing.T) {
 	require.NoError(t, err)
 	resp.Body.Close()
 
-	trace := tt.Traces()[0]
+	trace := traces.Last()
 	assert.Equal(t, "GET / HTTP/1.1\r\nHost: temba.io\r\nUser-Agent: Go-http-client/1.1\r\nContent-Length: 2\r\nX-Badness: \xc3(\r\nAccept-Encoding: gzip\r\n\r\n\xc3(", string(trace.RequestTrace))
 	assert.Equal(t, "HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n", string(trace.ResponseTrace))
 	assert.False(t, utf8.Valid(trace.RequestTrace))
@@ -186,7 +201,7 @@ func TestNonUTF8Request(t *testing.T) {
 }
 
 func TestNonUTF8Response(t *testing.T) {
-	ctx := context.Background()
+	ctx, traces := httpx.WithTraceCollector(context.Background())
 
 	tt := httpx.WithTraces(httpx.WithMocks(http.DefaultTransport, map[string][]*httpx.MockResponse{
 		"https://temba.io": {
@@ -201,7 +216,7 @@ func TestNonUTF8Response(t *testing.T) {
 	require.NoError(t, err)
 	resp.Body.Close()
 
-	trace := tt.Traces()[0]
+	trace := traces.Last()
 	assert.Equal(t, "GET / HTTP/1.1\r\nHost: temba.io\r\nUser-Agent: Go-http-client/1.1\r\nAccept-Encoding: gzip\r\n\r\n", string(trace.RequestTrace))
 	assert.Equal(t, "HTTP/1.0 200 OK\r\nContent-Length: 2\r\nX-Badness: \xc3(\r\n\r\n", string(trace.ResponseTrace))
 	assert.Equal(t, []byte{'\xc3', '\x28'}, trace.ResponseBody)
@@ -261,14 +276,17 @@ func TestTraceCollector(t *testing.T) {
 	assert.Equal(t, 200, traces3.Last().Response.StatusCode)
 	assert.Equal(t, []byte("final"), traces3.Last().ResponseBody)
 
-	// requests made without a collector still work, and are still recorded by the transport itself
-	tracer := httpx.WithTraces(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
+	// a request with no collector on its context is passed straight through - it still succeeds and its body is
+	// still readable, it just isn't traced and nothing is retained anywhere
+	soloClient := &http.Client{Transport: httpx.WithTraces(httpx.WithMocks(nil, map[string][]*httpx.MockResponse{
 		url: {httpx.NewMockResponse(200, nil, []byte("solo"))},
-	}))
+	}))}
 	req4, _ := http.NewRequest("GET", url, nil)
-	_, err = (&http.Client{Transport: tracer}).Do(req4)
+	resp, err = soloClient.Do(req4)
 	require.NoError(t, err)
-	assert.Len(t, tracer.Traces(), 1)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("solo"), body)
 
 	// an empty collector reports no traces rather than panicking
 	_, empty := httpx.WithTraceCollector(context.Background())
@@ -334,4 +352,53 @@ func TestTraceCollectorReadLimit(t *testing.T) {
 	_, err = io.ReadAll(resp.Body)
 	assert.ErrorIs(t, err, httpx.ErrResponseSize)
 	require.NotNil(t, traces.Last())
+}
+
+func TestTraceCollectorSharedContext(t *testing.T) {
+	// a transport slow enough that one request is still in flight while the other goroutine reads
+	client := &http.Client{Transport: httpx.WithTraces(roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		time.Sleep(20 * time.Millisecond)
+		return &http.Response{Status: "200 OK", StatusCode: 200, Proto: "HTTP/1.1", ProtoMajor: 1, ProtoMinor: 1,
+			Header: make(http.Header), Body: io.NopCloser(bytes.NewReader([]byte(r.URL.Path)))}, nil
+	}))}
+
+	// a context handed to several goroutines gives them one shared collector
+	ctx, traces := httpx.WithTraceCollector(context.Background())
+
+	wg := sync.WaitGroup{}
+	for i := range 4 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			req, _ := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://example.com/req-%d", i), nil)
+			resp, err := client.Do(req)
+			if assert.NoError(t, err) {
+				io.Copy(io.Discard, resp.Body)
+			}
+		}(i)
+	}
+
+	// meanwhile read the collector continuously - traces are only published once fully written, so under -race
+	// this must not catch a RoundTrip mid-write
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 100 {
+			for _, tr := range traces.Traces() {
+				_, _, _ = tr.Response, tr.ResponseBody, tr.EndTime
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	wg.Wait()
+
+	// every goroutine's trace lands in the shared collector, each one complete
+	all := traces.Traces()
+	require.Len(t, all, 4)
+	for _, tr := range all {
+		assert.NotNil(t, tr.Response)
+		assert.Equal(t, []byte(tr.Request.URL.Path), tr.ResponseBody)
+		assert.False(t, tr.EndTime.IsZero())
+	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #238, and a **breaking change**. The trace collector added there exists so tracing can be installed once on a shared client, but `WithTraces` also retained every trace it captured for its own `Traces()` list — on a process-lifetime client that's an unbounded leak holding every request and response body it ever saw. This removes the accumulating list entirely rather than adding a second constructor beside it, so there is one way to trace and no shape that leaks by default.

## Why remove it rather than add an alternative

Nothing was using the accumulated list because it wanted a list. Every caller was working around the absence of per-call traces by building a throwaway transport, and some by cloning the client to hang it on:

- `goflow/services/webhooks/service.go:77` — clones the client per call to install a fresh tracer
- courier's `utils/http.go` and mailroom's `utils/svclogs/request.go` — both build a per-call tracer, and both are being deleted in favour of the collector
- code that traces calls issued by a vendor SDK has to clone the client for the same reason, since it never gets to make the request itself

Keeping the accumulating mode would preserve a footgun that the obvious name leads you straight into, for a use case that turns out not to exist.

## Changes

`WithTraces(inner)` now returns a plain `http.RoundTripper` that records each request's trace into the `TraceCollector` on that request's context and nowhere else. It holds no state, so it belongs on the client when the client is built — including a long-lived shared one, or one handed to an SDK.

A request whose context carries no collector is passed straight through: no `DumpRequestOut`, no body buffering, nothing retained. Nobody asked for that call's trace, so none is taken and none of tracing's cost is paid.

The exported `TracesTransport` type and its `Traces()` method are gone.

## Behavior

| | Before | After |
|---|---|---|
| `WithTraces` return type | `*TracesTransport` | `http.RoundTripper` |
| Reading traces | `tt.Traces()` | `WithTraceCollector(ctx)` then `traces.Traces()` / `traces.Last()` |
| Retained on the transport | every trace, forever | nothing |
| Request with no collector | traced, buffered, retained | passed through untouched |

## Migration

```go
// before
tracing := httpx.WithTraces(inner)
client := *httpClient
client.Transport = tracing
resp, err := client.Do(req)
trace := tracing.Traces()[len(tracing.Traces())-1]

// after — client built once, with tracing already on it
ctx, traces := httpx.WithTraceCollector(req.Context())
resp, err := httpClient.Do(req.WithContext(ctx))
trace := traces.Last()
```

Because removing `Traces()` breaks the build for anyone who upgrades gocommon, downstream callers need updating in dependency order: `goflow` (its webhook service and one test) first, then the services that depend on it — which reach this API only through code being deleted in the same migration.

## Thread safety

A trace is handed to its collector only once every field has been written, not when the request starts. That matters because the collector's lock protects the slice, not the `Trace` structs in it — publishing up front would let a reader in another goroutine observe a trace that `RoundTrip` is still filling in. Deferring publication puts all the writes before the lock the reader acquires, which is the happens-before that makes a shared collector safe.

This is reachable whenever a context is passed to more than one goroutine, which the collector design makes an ordinary thing to do. `TestTraceCollectorSharedContext` covers it: four goroutines sharing one context while a fifth reads the collector continuously, verified with `-race`.

A shared collector is safe, but it is still *shared*: `Traces()` is the union of what every goroutine under that context did, and `Last()` is the most recent of those rather than the caller's own. Where each caller needs its own traces it needs its own collector, and the docs now say so. `Last()` is also documented as the most recently *completed* trace, which is what deferring publication makes it.

## Test plan

- [x] `go build ./...`, `go vet`, `gofmt -l` all clean
- [x] Full suite green in the devcontainer with the CI command (`go test -p=1 ./...`) — 23 packages, exit 0
- [x] Existing `httpx` tests converted to collectors rather than deleted, so the same behaviour is still asserted — request/response capture, sizes, non-UTF8 handling, read limits, retry counts, and log building
- [x] `TestTracesTransport` additionally asserts that a request with no collector is passed through and does not reach an earlier collector
- [x] `TestTracesTransportConcurrent` asserts each of 20 concurrent callers sees exactly its own trace
- [x] `TestTraceCollectorSharedContext` covers concurrent use of one shared collector under `-race`
- [x] `TestTraceCollector` covers isolation between successive calls, redirects recording every hop with `Last()` returning the final one, and an empty collector reporting nothing rather than panicking
